### PR TITLE
Update to home page d/l links

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,8 +30,8 @@
         <h1 class="heading-5-copy">That&#x27;s right, it&#x27;s back and its open source.</h1>
         <h1 class="heading-5-copy">AU, VST2, and VST3</h1>
         <h1 class="heading-5-copy">macOS, Windows, and Linux* (*coming soon)</h1>
-        <a href="https://github.com/surge-synthesizer/surge" class="hero-button w-button">Download for macOS </a>
-        <a href="https://github.com/surge-synthesizer/surge" class="hero-button w-button">Download for Windows </a>
+        <a href="https://github.com/surge-synthesizer/releases/releases/download/master/Surge-master-Setup.dmg" class="hero-button w-button">Download for macOS </a>
+        <a href="https://github.com/surge-synthesizer/releases/releases/download/master/Surge-master-Setup.exe" class="hero-button w-button">Download for Windows </a>
         <a href="#" class="hero-button not-active w-button">Linux Coming Soon!</a>
         <a href="https://surge-synthesizer.github.io/surge-manual/" class="hero-link">View Manual</a></div>
     </div>
@@ -170,8 +170,8 @@
       <div class="div-block-3">
         <h1 class="heading-2">Downloads</h1>
         <h3 class="heading-3">Latest Release: 1.6.0</h3>
-        <a href="https://github.com/surge-synthesizer/surge" class="button w-button">Download for macOS</a>
-        <a href="https://github.com/surge-synthesizer/surge" class="button w-button">Download for Windows</a>
+        <a href="https://github.com/surge-synthesizer/releases/releases/download/master/Surge-master-Setup.dmg" class="button w-button">Download for macOS</a>
+        <a href="https://github.com/surge-synthesizer/releases/releases/download/master/Surge-master-Setup.exe" class="button w-button">Download for Windows</a>
         <!--<a href="#" class="button not-active w-button">Linux Coming Soon!</a>-->
         <h3 class="heading-3">Nightly builds:</h3>
         <h3 class="heading-4 caution-text" style="line-height: 1.5rem;"><strong>Use caution, nightly builds may be volatile. <br><br>- the Management</strong></h3>


### PR DESCRIPTION
Quick update to get the downloads links pointing to the actual files to download instead of the github project page now that we have a releases branch.