### PR TITLE
Reccomended -> Recommended, add AU to Mac details

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="border-top-thin clearfix mt-2 mt-lg-4">
   <div class="container mx-auto px-2">
-    <p class="col-8 sm-width-full left py-2 mb-0">This project is maintained by the community at the GitHub Surge Synthesizer open source project<a class="text-accent" href="https://github.com/{{ site.github_username }}">{{ site.github_username }}</a></p>
+    <p class="col-8 sm-width-full left py-2 mb-0">This project is maintained by the community at the <a href="http://github.com/surge-synthesizer">GitHub Surge Synthesizer</a> open source project<a class="text-accent" href="https://github.com/{{ site.github_username }}">{{ site.github_username }}</a></p>
     <ul class="list-reset right clearfix sm-width-full py-2 mb-2 mb-lg-0">
       <li class="inline-block mr-1">
         <a href="https://twitter.com/share" class="twitter-share-button" data-hashtags="{{ site.title }}">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -156,7 +156,7 @@
         <div class="text-wrapper">
           <h3 class="spec-heading">Windows</h3>
           <p class="specs-text-wrapper">Windows 7 and a recent intel processor (at least Pentium 4 or above)</p>
-          <p class="specs-text-wrapper"><strong>Reccomended:</strong> A computer running Windows 7 64 bit or newer</p>
+          <p class="specs-text-wrapper"><strong>Recommended:</strong> A computer running Windows 7 64 bit or newer</p>
           <p class="specs-text-wrapper">A minimum of 4GB of RAM</p>
           <p class="specs-text-wrapper">A VST-compatible Host application</p>
           <p class="specs-text-wrapper">An x64-compatible CPU, OS and Host is required to use the 64-bit version</p>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -151,7 +151,7 @@
           <h3 class="spec-heading">mac</h3>
           <p class="specs-text-wrapper">An Intel MAC running at least macOS 10.11</p>
           <p class="specs-text-wrapper">A minimum of 4GB of RAM</p>
-          <p class="specs-text-wrapper">A VST-compatible Host application</p>
+          <p class="specs-text-wrapper">A VST-compatible or AU-compatible Host application</p>
         </div>
         <div class="text-wrapper">
           <h3 class="spec-heading">Windows</h3>


### PR DESCRIPTION
simple typo fix of `Recomended` to `Recommended`

Add AU to Mac details