### PR TITLE
Fixing footer buttons and reordering main site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
 <div class="border-top-thin clearfix mt-2 mt-lg-4">
   <div class="container mx-auto px-2">
     <p class="col-8 sm-width-full left py-2 mb-0">This project is maintained by the community at the <a href="http://github.com/surge-synthesizer">GitHub Surge Synthesizer</a> open source project<a class="text-accent" href="https://github.com/{{ site.github_username }}">{{ site.github_username }}</a></p>
-    <ul class="list-reset right clearfix sm-width-full py-2 mb-2 mb-lg-0">
-      <li class="inline-block mr-1">
+    <div class="right sm-width-full py-2 mb-2 mb-lg-0">
+      <div class="">
         <a href="https://twitter.com/share" class="twitter-share-button" data-hashtags="{{ site.title }}">Tweet</a> <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-      </li>
-      <li class="inline-block">
+      </div>
+      <div class="">
         <a class="github-button" href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}" data-icon="octicon-star" data-count-href="{{ site.github_username }}/{{ github_repo }}/stargazers" data-count-api="/repos/{{ site.github_username }}/{{ github_repo }}#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star {{ site.github_username }}/{{ github_repo }} on GitHub">Star</a>
-      </li>
-    </ul>
+      </div>
+    </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,54 +40,7 @@
     <div class="hero-right"></div>
   </div>
       
-      <div class="contributer-section">
-    <div class="contributer-text dark-text">
-      <div class="text-container">
-        <h1 class="h1 dark-text" style="text-align: left; margin-left: -4px;">Contributors Welcome!</h1>
-        <p>Surge is supported by a community of volunteer open source developers, designers, testers, musicians, synthesizer enthusiasts, and content creators.<br><br>Without them, none of this is possible. If you&#x27;re interested in seeing what&#x27;s going on with the project the best thing to do is:<br></p><a href="https://github.com/surge-synthesizer/surge" class="ghost-button-thick-border-blue">View the Surge Project Page</a></div>
-    </div>
-  </div>
-  <div class="developer-section-copy" style="background-color: #005db6;">
-    <div class="developer-hero"></div>
-    <div class="developer-text">
-      <div class="text-container">
-        <h3 class="heading-2 white-text" style="text-align: left">Developers</h3>
-        <p class="paragraph">If you are interested in contributing, we welcome developers who know or want to learn C++, git, and graphic and web design.<br><br>There’s plenty of open issues and our Slack channel can help you find a good first one if you want. <br><br>Hop over to the project issues page to see what we need help with. <br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border">View Surge-Synthesizer GitHub Project Page</a>
-        <p class="paragraph">You can also join the conversation at the Surge project&#x27;s Slack #general channel. We&#x27;ll help get you started!<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border">Join Surge Slack #general Channel</a></div>
-    </div>
-  </div>
-  <div class="designer-section" style="background-color: #ff8f02;">
-    <div class="designer-hero"></div>
-    <div class="designer-text black-text">
-      <div class="text-container">
-        <h3 style="color: #000;">Designers</h3>
-        <p>We need a logo.<br>Please <strong>send help</strong>.<br><br>(That was a joke, but we do <strong><em>actually</em></strong> need a logo!)<br><br>If you would like to pitch in and have interests in UX, UI, Visual Design or any other design related topic there are plenty of open issues. <br><br>The #design Slack channel can help find something to get you started.<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-black-text">Join #design Surge Slack Channel</a></div>
-    </div>
-  </div>
-  <div class="tester-section" style="background-color: #005db6;">
-    <div class="tester-hero"></div>
-    <div class="tester-text">
-      <div class="text-container">
-        <h3 class="white-text">Testers</h3>
-        <p class="white-text"><em>Know any testers? Umm, asking for a friend.</em><br><br>Testing is a way that everyone can help contribute. All you would need to do is install a copy of Surge.<br><br>There are so many combinations of OS&#x27;s and DAW host software that it is <em>really difficult </em>to make sure everything gets tested under all contexts. <br><br>If you would like to get involved jump in over here:<br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border">View Surge-Synthesizer GitHub Project Page</a></div>
-    </div>
-  </div>
-  <div class="content-creator-section" style="background-color: #ff8f02;">
-    <div class="content-creators-hero"></div>
-    <div class="content-creator-text black-text">
-      <div class="text-container">
-        <h3>Content Creators</h3>
-        <p>If you love to use Surge and make amazing presets or music we want to hear from you. <br><br>In fact, we would love to have you pitch in and help out with the project!<br><br>We are looking for people that have content that showcases Surge in all of its glory. <br><br>If you make patches, write entire songs using only Surge, or anything in between we would love for you to get involved. <br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border-black-text">View Surge-Synthesizer GitHub Project Page</a></div>
-    </div>
-  </div>
-  <div class="community-section">
-    <div class="community-text">
-      <div class="text-container">
-        <h1 class="heading dark-text" style="color: #133562; text-align: left;">Community</h1>
-        <p>We love Surge. We <strong><em>also</em></strong> love people. <br><br>Community is a <strong><em>big thing to us</em></strong> on this project. We want an inclusive, positive, and happy community with contributions from a large set of differing viewpoints and backgrounds.<br><br>Let&#x27;s be kind to each other and treat each other with respect. It takes <em>all of us working together</em> to make a great community.<br><br>We are looking forward to your insights and contributions. <br><br>Let&#x27;s make something amazing!<br><br>- The Management</p>
-        <a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-blue">Get Involved Here</a></div>
-    </div>
-  </div>
+      
       
   <div class="digital-section">
     <div class="digital-left"></div>
@@ -191,6 +144,55 @@
         <p class="specs-text-wrapper dark-text">10 top-quality algorithms: </p>
         <p class="specs-text-wrapper dark-text">Delay, Reverb, Chorus, Phaser, EQ, Distortion, Conditioner (EQ, stereo-image control, and limiter), Rotary speaker, Frequency shifter, Vocoder</p>
       </div>
+    </div>
+  </div>
+      
+      <div class="contributer-section">
+    <div class="contributer-text dark-text">
+      <div class="text-container">
+        <h1 class="h1 dark-text" style="text-align: left; margin-left: -4px;">Contributors Welcome!</h1>
+        <p>Surge is supported by a community of volunteer open source developers, designers, testers, musicians, synthesizer enthusiasts, and content creators.<br><br>Without them, none of this is possible. If you&#x27;re interested in seeing what&#x27;s going on with the project the best thing to do is:<br></p><a href="https://github.com/surge-synthesizer/surge" class="ghost-button-thick-border-blue">View the Surge Project Page</a></div>
+    </div>
+  </div>
+  <div class="developer-section-copy" style="background-color: #005db6;">
+    <div class="developer-hero"></div>
+    <div class="developer-text">
+      <div class="text-container">
+        <h3 class="heading-2 white-text" style="text-align: left">Developers</h3>
+        <p class="paragraph">If you are interested in contributing, we welcome developers who know or want to learn C++, git, and graphic and web design.<br><br>There’s plenty of open issues and our Slack channel can help you find a good first one if you want. <br><br>Hop over to the project issues page to see what we need help with. <br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border">View Surge-Synthesizer GitHub Project Page</a>
+        <p class="paragraph">You can also join the conversation at the Surge project&#x27;s Slack #general channel. We&#x27;ll help get you started!<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border">Join Surge Slack #general Channel</a></div>
+    </div>
+  </div>
+  <div class="designer-section" style="background-color: #ff8f02;">
+    <div class="designer-hero"></div>
+    <div class="designer-text black-text">
+      <div class="text-container">
+        <h3 style="color: #000;">Designers</h3>
+        <p>We need a logo.<br>Please <strong>send help</strong>.<br><br>(That was a joke, but we do <strong><em>actually</em></strong> need a logo!)<br><br>If you would like to pitch in and have interests in UX, UI, Visual Design or any other design related topic there are plenty of open issues. <br><br>The #design Slack channel can help find something to get you started.<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-black-text">Join #design Surge Slack Channel</a></div>
+    </div>
+  </div>
+  <div class="tester-section" style="background-color: #005db6;">
+    <div class="tester-hero"></div>
+    <div class="tester-text">
+      <div class="text-container">
+        <h3 class="white-text">Testers</h3>
+        <p class="white-text"><em>Know any testers? Umm, asking for a friend.</em><br><br>Testing is a way that everyone can help contribute. All you would need to do is install a copy of Surge.<br><br>There are so many combinations of OS&#x27;s and DAW host software that it is <em>really difficult </em>to make sure everything gets tested under all contexts. <br><br>If you would like to get involved jump in over here:<br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border">View Surge-Synthesizer GitHub Project Page</a></div>
+    </div>
+  </div>
+  <div class="content-creator-section" style="background-color: #ff8f02;">
+    <div class="content-creators-hero"></div>
+    <div class="content-creator-text black-text">
+      <div class="text-container">
+        <h3>Content Creators</h3>
+        <p>If you love to use Surge and make amazing presets or music we want to hear from you. <br><br>In fact, we would love to have you pitch in and help out with the project!<br><br>We are looking for people that have content that showcases Surge in all of its glory. <br><br>If you make patches, write entire songs using only Surge, or anything in between we would love for you to get involved. <br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border-black-text">View Surge-Synthesizer GitHub Project Page</a></div>
+    </div>
+  </div>
+  <div class="community-section">
+    <div class="community-text">
+      <div class="text-container">
+        <h1 class="heading dark-text" style="color: #133562; text-align: left;">Community</h1>
+        <p>We love Surge. We <strong><em>also</em></strong> love people. <br><br>Community is a <strong><em>big thing to us</em></strong> on this project. We want an inclusive, positive, and happy community with contributions from a large set of differing viewpoints and backgrounds.<br><br>Let&#x27;s be kind to each other and treat each other with respect. It takes all of us working together to make a community great.<br><br>We are looking forward to your insights and contributions. <br><br>Let&#x27;s make something amazing!<br><br>- The Management</p>
+        <a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-blue">Get Involved Here</a></div>
     </div>
   </div>
       

--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -678,7 +678,7 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 70px;
   font-weight: 400;
   text-align: left;
-  margin-left: -4px;
+  margin-left: -5px;
 }
 
 .paragraph {

--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -45,6 +45,11 @@ $h6-size: 0.618em !default;
   }
 }
 
+sup {
+  vertical-align: top; 
+  font-size: 0.6em;
+}
+
 .header-background { 
 //  background-image: linear-gradient(-180deg, #000000 0%, #232323 100%); 
 //  overflow: hidden; 


### PR DESCRIPTION
I made it so that the social buttons in the footer now are stacked. They were getting wonky in Safari when you resized your browser. That is fixed now.

Based on the slack #design channel I reorderd the sections to this:

The basic flow down the page that is being proposed is the following:

Hero section (d/l’s with giant screen shot)
Digital Beauty
Sounds
Surge is back and Open Source (giving props to kurasu for the OSS :heart:)
Specifications
Contribution stuff
System req’s