### PR TITLE
Add a placeholder url for rack_manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
+.Gemfile.swp

--- a/rack_manual/rack_manual.md
+++ b/rack_manual/rack_manual.md
@@ -1,0 +1,9 @@
+---
+title: Surge in VCVRack
+permalink: /rack_manual/
+---
+
+We are undertaking work to make Surge components available in VCV Rack. A manual is coming soon.
+
+For now, see the reference at [the project github page, https://github.com/surge-synthesizer/surge-rack/](https://github.com/surge-synthesizer/surge-rack/).
+


### PR DESCRIPTION
Add a placeholder URL for the VCV Rack Manual I am yet to
write but will probably write real soon now, like this week.
Need this so I can have a URL for the plugin.json