### PR TITLE
Move Slack Link to an Include

### DIFF
--- a/_includes/community.html
+++ b/_includes/community.html
@@ -3,7 +3,7 @@
     <div class="text-container">
       <h1 class="heading dark-text community-header">Community</h1>
       <p>We love Surge. We <strong><em>also</em></strong> love people. <br><br>Community is a <strong><em>big thing to us</em></strong> on this project. We want an inclusive, positive, and happy community with contributions from a large set of differing viewpoints and backgrounds.<br><br>Let&#x27;s be kind to each other and treat each other with respect. It takes all of us working together to make a community great.<br><br>We are looking forward to your insights and contributions. <br><br>Let&#x27;s make something amazing!<br><br>- The Management</p>
-      <a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-blue">Get Involved Here</a>
+      <a href="{% include slack_invite_link %}" class="ghost-button-thick-border-blue">Get Involved Here</a>
     </div>
   </div>
 </div>

--- a/_includes/designers.html
+++ b/_includes/designers.html
@@ -3,7 +3,7 @@
   <div class="designer-text black-text">
     <div class="text-container">
       <h3 >Designers</h3>
-      <p>We need a logo.<br>Please <strong>send help</strong>.<br><br>(That was a joke, but we do <strong><em>actually</em></strong> need a logo!)<br><br>If you would like to pitch in and have interests in UX, UI, Visual Design or any other design related topic there are plenty of open issues. <br><br>The #design Slack channel can help find something to get you started.<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border-black-text">Join #design Surge Slack Channel</a>
+      <p>We need a logo.<br>Please <strong>send help</strong>.<br><br>(That was a joke, but we do <strong><em>actually</em></strong> need a logo!)<br><br>If you would like to pitch in and have interests in UX, UI, Visual Design or any other design related topic there are plenty of open issues. <br><br>The #design Slack channel can help find something to get you started.<br></p><a href="{% include slack_invite_link %}" class="ghost-button-thick-border-black-text">Join #design Surge Slack Channel</a>
     </div>
   </div>
 </div>

--- a/_includes/developers.html
+++ b/_includes/developers.html
@@ -4,7 +4,8 @@
     <div class="text-container">
       <h3 class="heading-2 white-text developer-heading">Developers</h3>
       <p class="paragraph">If you are interested in contributing, we welcome developers who know or want to learn C++, git, and graphic and web design.<br><br>There’s plenty of open issues and our Slack channel can help you find a good first one if you want. <br><br>Hop over to the project issues page to see what we need help with. <br></p><a href="https://github.com/surge-synthesizer/surge/issues" class="ghost-button-thick-border">View Surge-Synthesizer GitHub Project Page</a>
-      <p class="paragraph">You can also join the conversation at the Surge project&#x27;s Slack #general channel. We&#x27;ll help get you started!<br></p><a href="https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU" class="ghost-button-thick-border">Join Surge Slack #general Channel</a>
+      <p class="paragraph">You can also join the conversation at the Surge project&#x27;s Slack #general channel. We&#x27;ll help get you started!<br></p>
+      <a href="{% include slack_invite_link %}" class="ghost-button-thick-border">Join Surge Slack #general Channel</a>
     </div>
   </div>
 </div>

--- a/_includes/slack_invite_link
+++ b/_includes/slack_invite_link
@@ -1,0 +1,1 @@
+https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LWZkMjllNDAzZjYzNTc4NjUzNjk2OGUxNDYzZTYyZTU3ZGU4OTY4MzhkNzcwZGE5ZDQyMzk5MjE1ODEzZTFmODI

--- a/feedback.md
+++ b/feedback.md
@@ -10,7 +10,8 @@ thanks to a dedicated group of musicians who gave patient and clear feedback on 
 ideas for new and improved features. We invite you to share your feedback too.
 
 The best way to reach the development team is either to open an issue on 
-our [GitHub issue page](https://github.com/surge-synthesizer/surge/issues) or [join our slack](https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU) and chat with us.
+our [GitHub issue page](https://github.com/surge-synthesizer/surge/issues) or [join our slack]({% include slack_invite_link %})
+and chat with us.
 
 And good bug reports make good software! So please feel free to open a github issue! But there are some guidelines which may help.
 

--- a/manual/Surge.md
+++ b/manual/Surge.md
@@ -1662,7 +1662,7 @@ The list is as follows:
 
 ## Questions?
 
-Feel free to visit the Surge Synth Slack ([here]( https://join.slack.com/t/surgesynth/shared_invite/enQtNTE4OTg0MTU2NDY5LTE4MmNjOTBhMjU5ZjEwNGU5MjExODNhZGM0YjQxM2JiYTI5NDE5NGZkZjYxZTkzODdiNTM0ODc1ZmNhYzQ3NTU)) if you have questions about Surge, want to help in developing it further or if you come across any bugs or other issues.
+Feel free to visit the Surge Synth Slack ([here]({% include slack_invite_link %}) if you have questions about Surge, want to help in developing it further or if you come across any bugs or other issues.
 
 <br/>
 <br/>


### PR DESCRIPTION
The slack link was used several places in the website making
updating it annoying. So make an include file which has it
and use that on the web properties.