### PR TITLE
Hero text margin was creating issue on mobile where the white BG of the page would show through

### DIFF
--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -71,6 +71,8 @@ sup {
   //  overflow: hidden; 
   //  height: 100vh;}
   padding: $spacer-1;
+  padding-left: 2rem;
+  padding-right: 2rem;
   //  overflow: hidden;
   background-color: black;
   //    float: right;
@@ -716,7 +718,7 @@ h6 {
   justify-content: center;
   align-items: flex-start;
   color: #fff;
-  margin-top: 4rem;
+  // margin-top: 4rem;
 }
 
 .hero-heading {
@@ -1325,7 +1327,7 @@ pre {
     padding-left: 0rem;
     padding-bottom: 2rem;
     align-items: center;
-    margin-top: 4rem;
+    // margin-top: 4rem;
   }
 
   .hero-heading {


### PR DESCRIPTION
Fixed the margin on the hero text portion so that it doesnt push the hero area below nav any longer.