### PR TITLE
fixing scrolling to sections in the manual

### DIFF
--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -13,6 +13,7 @@ a {
 html {
     font-size: 16px;
     scroll-behavior: smooth;
+    scroll-padding-top: 4.375rem;
 }
 
 body {
@@ -1493,25 +1494,25 @@ select {
     --primary-color: #ff9000;
     --overlay-color: rgba(24, 39, 51, 0.85);
     --menu-speed: 0.25s;
-  }
-  
-  * {
+}
+
+* {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-  }
-  
-  /* MENU STYLES */
-  .menu-wrap {
+}
+
+/* MENU STYLES */
+.menu-wrap {
     // position: relative;
     // top: 0;
     // left: 0;
     z-index: 1;
     // margin: 0 1rem;
     width: 50%;
-  }
-  
-  .menu-wrap .toggler {
+}
+
+.menu-wrap .toggler {
     position: absolute;
     // top: 0;
     // left: 0;
@@ -1522,9 +1523,9 @@ select {
     opacity: 0;
     height: 100%;
     width: 60px;
-  }
-  
-  .menu-wrap .hamburger {
+}
+
+.menu-wrap .hamburger {
     position: absolute;
     // top: 0;
     // right: 0;
@@ -1536,10 +1537,10 @@ select {
     display: flex;
     align-items: center;
     // justify-content: center;
-  }
-  
-  /* Hamburger Line */
-  .menu-wrap .hamburger > div {
+}
+
+/* Hamburger Line */
+.menu-wrap .hamburger > div {
     position: relative;
     flex: none;
     width: 48px;
@@ -1549,12 +1550,12 @@ select {
     align-items: center;
     justify-content: center;
     transition: all 0.4s ease;
-    margin-right: .5rem;
-  }
-  
-  /* Hamburger Lines - Top & Bottom */
-  .menu-wrap .hamburger > div::before,
-  .menu-wrap .hamburger > div::after {
+    margin-right: 0.5rem;
+}
+
+/* Hamburger Lines - Top & Bottom */
+.menu-wrap .hamburger > div::before,
+.menu-wrap .hamburger > div::after {
     content: "";
     position: absolute;
     z-index: 1;
@@ -1562,44 +1563,43 @@ select {
     width: 100%;
     height: 4px;
     background: inherit;
-  }
-  
-  /* Moves Line Down */
-  .menu-wrap .hamburger > div::after {
+}
+
+/* Moves Line Down */
+.menu-wrap .hamburger > div::after {
     top: 10px;
-  }
+}
 
 //   .menu-wrap .toggler:checked + .hamburger {
 //     width: 60px;
 //     padding: .5rem;
 //    }
-   
-  
-  /* Toggler Animation */
-  .menu-wrap .toggler:checked + .hamburger > div {
+
+/* Toggler Animation */
+.menu-wrap .toggler:checked + .hamburger > div {
     transform: rotate(135deg);
-  }
-  
-  /* Turns Lines Into X */
-  .menu-wrap .toggler:checked + .hamburger > div:before,
-  .menu-wrap .toggler:checked + .hamburger > div:after {
+}
+
+/* Turns Lines Into X */
+.menu-wrap .toggler:checked + .hamburger > div:before,
+.menu-wrap .toggler:checked + .hamburger > div:after {
     top: 0;
     transform: rotate(90deg);
-  }
-  
-  /* Rotate On Hover When Checked */
-  .menu-wrap .toggler:checked:hover + .hamburger > div {
+}
+
+/* Rotate On Hover When Checked */
+.menu-wrap .toggler:checked:hover + .hamburger > div {
     transform: rotate(225deg);
-  }
-  
-  /* Show Menu */
-  .menu-wrap .toggler:checked + .hamburger {
-      width: 60px;
-      padding: 1rem;
-  }
-  .menu-wrap .toggler:checked ~ .menu {
+}
+
+/* Show Menu */
+.menu-wrap .toggler:checked + .hamburger {
+    width: 60px;
+    padding: 1rem;
+}
+.menu-wrap .toggler:checked ~ .menu {
     visibility: visible;
-  }
+}
 
 //   body + .header .menu-wrap .toggler:checked {
 //       overflow: hidden;
@@ -1619,18 +1619,18 @@ select {
 //     right: 0;
 //     bottom: 0;
 //   }
-  
-  .menu-wrap .toggler:checked ~ .menu > div {
+
+.menu-wrap .toggler:checked ~ .menu > div {
     transform: scale(1.25);
     transition-duration: var(--menu-speed);
-  }
-  
-  .menu-wrap .toggler:checked ~ .menu > div > div {
+}
+
+.menu-wrap .toggler:checked ~ .menu > div > div {
     opacity: 1;
     // transition: opacity 0.4s ease 0.4s;
-  }
-  
-  .menu-wrap .menu {
+}
+
+.menu-wrap .menu {
     position: fixed;
     top: 0;
     left: 0;
@@ -1641,9 +1641,9 @@ select {
     display: flex;
     align-items: center;
     justify-content: center;
-  }
-  
-  .menu-wrap .menu > div {
+}
+
+.menu-wrap .menu > div {
     background: var(--overlay-color);
     border-radius: 50%;
     width: 200vw;
@@ -1654,32 +1654,32 @@ select {
     justify-content: center;
     transform: scale(0);
     transition: all 60ms ease-in-out;
-  }
-  
-  .menu-wrap .menu > div > div {
+}
+
+.menu-wrap .menu > div > div {
     text-align: center;
     max-width: 90vw;
     max-height: 100vh;
     opacity: 0;
     // transition: opacity 0.4s ease;
-  }
-  
-  .menu-wrap .menu > div > div > ul > li {
+}
+
+.menu-wrap .menu > div > div > ul > li {
     list-style: none;
     color: #fff;
     font-size: 1.5rem;
     padding: 1rem;
-  }
-  
-  .menu-wrap .menu > div > div > ul > li > a {
+}
+
+.menu-wrap .menu > div > div > ul > li > a {
     color: inherit;
     text-decoration: underline;
     // transition: color 0.4s ease;
-  }
-  
-  .menu-wrap .toggler:checked + .hamburger {
+}
+
+.menu-wrap .toggler:checked + .hamburger {
     width: 60px;
-    padding: .45rem;
+    padding: 0.45rem;
 }
 
 //////////////////////////
@@ -2163,7 +2163,7 @@ select {
     }
 
     select {
-        margin-right: .5rem;
+        margin-right: 0.5rem;
     }
 
     #manualLinks {
@@ -2262,7 +2262,7 @@ select {
     }
 
     .menu-wrap .menu > div > div > ul > li {
-        padding: .5rem;
+        padding: 0.5rem;
     }
 
     * {
@@ -2271,5 +2271,4 @@ select {
         -ms-animation: none !important;
         animation: none !important;
     }
-       
 }


### PR DESCRIPTION
The header is fixed, the sections were getting tucked up underneath the header when clicking on a section in the manual TOC.

This fixes that issue by adding padding to the top of the scroll.

Support for this new(ish) CSS feature seems pretty good. It hits all majors except for IE 11.....

https://caniuse.com/?search=scroll-padding-top