### PR TITLE
added margin-top for alignment

### DIFF
--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -583,6 +583,7 @@ h6 {
     font-weight: 400;
     text-align: left;
     text-transform: uppercase;
+    margin-top: 1rem;
 }
 
 .spec-heading.dark-text {


### PR DESCRIPTION
The system requirements and the download headers were misaligned. Added 1 rem to the spec heading class so that the alignment was uniform.