### PR TITLE
Hamburger Menu Fix

### DIFF
--- a/_sass/_surge.scss
+++ b/_sass/_surge.scss
@@ -1671,7 +1671,7 @@ select {
     height: 100%;
     visibility: hidden;
     overflow-x: hidden;
-    overflow-y: auto;
+    overflow-y: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1679,9 +1679,9 @@ select {
 
 .menu-wrap .menu > div {
     background: var(--overlay-color);
-    border-radius: 50%;
-    width: 200vw;
-    height: 200vw;
+ //   border-radius: 50%;
+    width: 100%;
+    height: 100%;
     display: flex;
     flex: none;
     align-items: center;
@@ -1702,7 +1702,7 @@ select {
     list-style: none;
     color: #fff;
     font-size: 1.5rem;
-    padding: 1rem;
+    padding: .35rem;
 }
 
 .menu-wrap .menu > div > div > ul > li > a {
@@ -2296,7 +2296,7 @@ select {
     }
 
     .menu-wrap .menu > div > div > ul > li {
-        padding: 0.5rem;
+        padding: 0.35rem;
     }
 
     * {


### PR DESCRIPTION
Fixing the issue with the hamburger menu overflowing. 

Now you should not be able to scroll the menu for no reason. 

The menu overlay should always be visible now with no curve to the top or bottom.

Slight change to the ul items padding to make sure it all fits on screen.

Tested in devtools with these devices:
<img width="219" alt="Screenshot 2022-12-07 at 11 01 50 PM" src="https://user-images.githubusercontent.com/11078351/206361374-598913e0-5bb8-44b2-bff6-4caa08f5fd5f.png">

Happy holidays.
