### PR TITLE
Add 'Playing Your First Note' section to 'Getting Started' 

### DIFF
--- a/manual_xt/Surge-XT.md
+++ b/manual_xt/Surge-XT.md
@@ -158,6 +158,13 @@ put them in your user data folder instead of here, or risk losing them when you 
 
 <br>
 
+## Playing Your First Note
+
+Surge XT is most comfortably used with a [DAW](https://en.wikipedia.org/wiki/Digital_audio_workstation), or a physical device such as a keyboard. To get started however, you can make
+use of the virtual keyboard (see [Workflow](#Workflow)), which can be opened from `menu -> workflow -> virtual keyboard`, or `alt+k`.
+
+Each note you play will be simulated based on the current Patch, so it's the perfect way to experiment before tackling a more complex setup.
+
 # User Interface Basics
 
 The user-interface of Surge XT is divided into four main sections:


### PR DESCRIPTION
I don't feel strongly about the structure here. My goal was to put something into the 'Getting Started' section, as I believe "Make Surge XT play a sound" is an important first step for newcomers :)

If the structure here is rejected, my second suggestion would be to add it to '[User Interface Basics](https://surge-synthesizer.github.io/manual-xt/#user-interface-basics)', although that would probably require taking and annotating a new screenshot. 

Lastly, it's worth mentioning that the virtual keyboard *is* lightly documented as part of the 'Workflow' section; I just didn't find it via searching: A read the full setup guide, and then searched for keywords like "play" or "simulate" or "run". 