### PR TITLE
Fix tuning guide 404 link

### DIFF
--- a/src/content/manual_xt/06-modulation-routing.mdx
+++ b/src/content/manual_xt/06-modulation-routing.mdx
@@ -357,8 +357,7 @@ Furthermore, holding down **Shift + Alt** makes two times more values available,
 useful when modulating pitch by **two octaves** instead.
 
 For more information on microtonal pitch modulation using the step sequencer, visit our
-[Tuning Guide](../tuning_guide/#Surge-XT-Microtonal-Step-Sequencing)
-on Surge's wiki.
+[Tuning Guide](../tuning-guide/#microtonal-step-sequencing).
 
 The step sequencers inside **voice LFOs** have an extra lane at the top of the
 step editor allowing to re-trigger the two regular voice envelopes


### PR DESCRIPTION
Fixed dead link and removed "on the wiki" text. There *is* such a page on the wiki, but it looks like the intended target is the manual page and not the wiki page.