### PR TITLE
manual-xt ch04 style, ch03 tweaks

### DIFF
--- a/src/content/manual_xt/01-getting_started.mdx
+++ b/src/content/manual_xt/01-getting_started.mdx
@@ -6,9 +6,9 @@ order: 1
 
 ![](/images/manual-xt/Pictures/surge.png)
 
-# Getting Started
+# Getting started
 
-If you're using Surge 1.9, see the [Manual for Surge 1.9](/manual).
+If you're using Surge 1.9, use the [Manual for Surge 1.9](/manual).
 
 Surge XT is a virtual synthesizer originally released as "Surge" as open source by creator Claes Johanson in September 2018. Since then, it's maintained by the Surge Synth Team, a group of volunteers.
 
@@ -18,8 +18,13 @@ This manual has main sections:
 - [Accessibility](#accessibility)
 - [Technical Reference](#technical-reference), with specifications and details of the synthesis engine.
 
-Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI, and Windows keyboard labels.
-
 For tutorials, tips, and more content, see the [Surge wiki](https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki).
 
 To ask questions, report bugs or issues, or help develop Surge XT, visit the [Surge Synth Team Discord server](https://discord.com/invite/spGANHw).
+
+Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI, and Windows keyboard labels.
+
+Trademarks:
+
+- Audio Units, AU is a trademark of Apple Computer, Inc
+- VST is a trademark of Steinberg Media Technologies GmbH

--- a/src/content/manual_xt/01-getting_started.mdx
+++ b/src/content/manual_xt/01-getting_started.mdx
@@ -18,7 +18,7 @@ This manual has main sections:
 - [Accessibility](#accessibility)
 - [Technical Reference](#technical-reference), with specifications and details of the synthesis engine.
 
-Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI.
+Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI, and Windows keyboard labels.
 
 For tutorials, tips, and more content, see the [Surge wiki](https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki).
 

--- a/src/content/manual_xt/02_installing_or_building.mdx
+++ b/src/content/manual_xt/02_installing_or_building.mdx
@@ -6,11 +6,6 @@ order: 2
 
 # Installing or Building Surge XT
 
-Trademarks:
-
-- Audio Units, AU is a trademark of Apple Computer, Inc
-- VST is a trademark of Steinberg Media Technologies GmbH
-
 Download the Surge XT installer from [https://surge-synthesizer.github.io](https://surge-synthesizer.github.io).
 
 

--- a/src/content/manual_xt/02_installing_or_building.mdx
+++ b/src/content/manual_xt/02_installing_or_building.mdx
@@ -4,7 +4,7 @@ slug: installing-or-building
 order: 2
 ---
 
-# Installing or Building Surge XT
+# Installing or building Surge XT
 
 Download the Surge XT installer from [https://surge-synthesizer.github.io](https://surge-synthesizer.github.io).
 
@@ -76,19 +76,19 @@ A list of required packages is listed in the source and in the deb file.
 environment. To solve that issue, disable the global gesture in the desktop environment.
 
 
-## Building from Source
+## Building from source
 
 To build Surge XT from source, see
 [our Github repository](https://github.com/surge-synthesizer/surge).
 
 
-## Installing Alongside Older Versions
+## Installing alongside older versions
 
 Surge and Surge XT are different plug-ins. This means that you can install Surge XT alongside Surge 1.9 or earlier.
 Keep Surge 1.9 installed to open projects that use older versions of Surge.
 
 
-## Standalone Version Options
+## Standalone version options
 
 If you are running Surge XT as a standalone executable, options at the top-left:
 - configure MIDI and audio inputs and outputs
@@ -127,7 +127,7 @@ The user patches are at `~/Documents/Surge XT`. Surge XT creates this directory 
 or change the user default settings for the first time.
 
 
-## Playing Your First Note
+## Playing your first note
 
 Surge XT is best used with a [DAW](https://en.wikipedia.org/wiki/Digital_audio_workstation), or a physical device
 like a keyboard. To get started, you can open the virtual keyboard from the main menu > **Workflow** > **Virtual Keyboard**,

--- a/src/content/manual_xt/02_installing_or_building.mdx
+++ b/src/content/manual_xt/02_installing_or_building.mdx
@@ -66,9 +66,11 @@ It is also offered as a standalone application.
 
 The system requirements can be hard to determine, as there are many Linux distributions, and other factors.
 
-- The installation package on the **Surge XT website** is a Debian package.
-- The distribution package is built on Ubuntu 18.04.
-- A list of required packages is listed in the source and in the deb file.
+The installation package on the **Surge XT website** is a Debian package.
+
+The distribution package is built on Ubuntu 18.04.
+
+A list of required packages is listed in the source and in the deb file.
 
 **Note:** Some actions in Surge XT use Alt + Drag or the scroll wheel, which can conflict with the desktop
 environment. To solve that issue, disable the global gesture in the desktop environment.
@@ -108,16 +110,19 @@ The Surge XT installer never changes files the user area, so save your files the
 ### Windows
 
 The patch library and wavetables are at `C:ProgramData\Surge XT`.
+
 The user patches are at `C:\Users\your username\My Documents\Surge XT`.
 
 ### macOS
 
 The patch library and wavetables are at `/Library/Application Support/Surge XT`.
+
 The user patches are at `~/Documents/Surge XT`.
 
 ### Linux
 
 The patch library and wavetables are at `/usr/share/surge-xt` with a standard install.
+
 The user patches are at `~/Documents/Surge XT`. Surge XT creates this directory when you store a patch
 or change the user default settings for the first time.
 
@@ -125,5 +130,5 @@ or change the user default settings for the first time.
 ## Playing Your First Note
 
 Surge XT is best used with a [DAW](https://en.wikipedia.org/wiki/Digital_audio_workstation), or a physical device
-like a keyboard. To get started, you can open the virtual keyboard from `Menu > Workflow > Virtual keyboard`,
+like a keyboard. To get started, you can open the virtual keyboard from the main menu > **Workflow** > **Virtual Keyboard**,
 or Alt + K. See [Workflow](#workflow).

--- a/src/content/manual_xt/03-user-interface-basics.mdx
+++ b/src/content/manual_xt/03-user-interface-basics.mdx
@@ -4,7 +4,7 @@ slug: user-interface-basics
 order: 3
 ---
 
-# User Interface Basics
+# User interface basics
 
 Surge XT displays four main sections: header, scene controls, modulation and routing, and effects.
 
@@ -12,7 +12,7 @@ Surge XT displays four main sections: header, scene controls, modulation and rou
 
 _The four sections of Surge XT._
 
-## The Scene Concept
+## <a name="the-scene-concept"></a>Scenes
 
 Every patch in Surge XT contains two scenes (A & B) and an effects section.
 A scene is similar to a traditional synthesizer patch that stores all the information used to synthesize a voice.
@@ -31,7 +31,7 @@ When loaded into a DAW, each instance of Surge XT has 3 audio outputs:
 
 If your host allows, you can route and process those outputs separately.
 
-## Sliders and Controls
+## Sliders and controls
 
 Surge XT parameters display as number fields, value fields, buttons, button groups, or sliders.
 
@@ -56,16 +56,16 @@ Other slider actions:
 ### Undo and Redo
 
 To undo or redo your latest changes, select the curved arrow buttons to the left of the **Save** button
-below the [Patch Browser](#patch-browser). You can also use default keyboard shortcuts: Ctrl + Z to undo,
+below the [Patch Browser](#patch-browser). You can also press Ctrl + Z to undo,
 and Ctrl + Y to redo.
 
-### Parameter Context Menu
+### Parameter context menu
 
 To display a parameter context menu, right-click.
 
 ![Illustration 3: Slider context menu](/images/manual-xt/Pictures/slider_context_menu.png)
 
-#### Name and Contextual Help
+#### Name and contextual help
 
 For help with a parameter, select the **?** option, or hover the parameter and press F1.
 
@@ -96,7 +96,7 @@ a slider displays "TS".
 #### Enabled
 
 You can enable or disable some parameters. Toggle **Enabled** in its context menu. A disabled slider
-displays faintly or has no handle.
+displays dimmed or has no handle.
 
 #### Modulations
 
@@ -106,12 +106,12 @@ See [Routing](#routing). For a modulation row:
 
 - To clear a modulation routing, select the red **X** icon.
 - To toggle bypassing a modulation routing, select the speaker icon.
-- To edit the modulation amout, select the pencil icon and type a value. See [Edit Value](#edit-value).
+- To edit the modulation amount, select the pencil icon and type a value. See [Edit Value](#edit-value).
 
 #### Add Modulation From
 
 To select a new modulation source, select **Add Modulation From**, then select a modulation source and
-enter the modulation value.
+enter a modulation value.
 
 #### Assign To MIDI CC
 
@@ -139,7 +139,7 @@ The assigned or learned MIDI controller displays next to **Clear Learned MIDI** 
 
 To clear the assigned or learned MIDI controller, select **Clear Learned MIDI**.
 
-#### VST3 Options
+#### VST3 options
 
 If you use the VST version of Surge XT, options from your host display at the end of the context menu.
 These options might help with automation, MIDI, or parameter values.

--- a/src/content/manual_xt/03-user-interface-basics.mdx
+++ b/src/content/manual_xt/03-user-interface-basics.mdx
@@ -29,7 +29,7 @@ When loaded into a DAW, each instance of Surge XT has 3 audio outputs:
 - Scene A Out
 - Scene B Out
 
-You can route and process those outputs separately if your host allows it.
+If your host allows, you can route and process those outputs separately.
 
 ## Sliders and Controls
 
@@ -72,7 +72,7 @@ For help with a parameter, select the **?** option, or hover the parameter and p
 #### Edit Value
 
 Select **Edit Value** then enter a value. There is no need to enter the unit of the entered value.
-Press Enter to commit the change. To exit without committing the change, press Escape or move another parameter.
+Press Enter to commit the change. To exit without committing the change, press Escape or focus elsewhere.
 
 ![Illustration 4: Type-in window](/images/manual-xt/Pictures/typein_window.png)
 
@@ -82,11 +82,11 @@ For a discrete parameter, like **Unison Voices** or a button row, select a value
 
 #### Extend Range
 
-You can extend the range of some parameters, like **Pitch**. Select **Extend Range** from their context menu.
+You can extend the range of some parameters, like **Pitch**. Select **Extend Range** from its context menu.
 
 #### Tempo Sync
 
-You can synchronize some parameters to the host tempo by toggling **Tempo Sync**. With **Tempo Sync** enabled,
+You can synchronize some parameters to the host tempo. Toggle **Tempo Sync**. With **Tempo Sync** enabled,
 a slider displays "TS".
 
 ![Illustration 6: Tempo sync slider](/images/manual-xt/Pictures/ts_slider.png)
@@ -115,7 +115,7 @@ enter the modulation value.
 
 #### Assign To MIDI CC
 
-To assign a parameter to a MIDI controller:
+To assign the parameter a MIDI controller:
 
 1. Select **Assign to MIDI CC** from the parameter context menu.
 2. Select a MIDI controller code. You can select codes 0 to 127, but some codes are reserved for other uses.

--- a/src/content/manual_xt/04-header.mdx
+++ b/src/content/manual_xt/04-header.mdx
@@ -8,140 +8,147 @@ order: 4
 
 ![Illustration 7: Header section](/images/manual-xt/Pictures/header.png)
 
+In the header, you can select and manage patches, select scene modes, configure MPE, configure tuning, select zoom, bypass effects, and control and monitor output.
+
 ## Scene Select and Scene Mode
 
 ![Illustration 8: Scene select and scene mode](/images/manual-xt/Pictures/scene_select.png)
 
-There are two setups of all controls within the Scene section of the user interface.
-The **Scene Select** buttons **[A|B]** determine which one is selected for editing.
-Right-clicking on these buttons brings up a context menu that allows you to copy/paste scene content.
+Select **Scene** buttons **A** or **B** to select a scene. The selected scene displays below.
 
-Depending on the **Scene Mode**, these two buttons could also be used to choose which scene will be _played_.
-Indeed, whether a scene will generate a voice when a key is pressed is determined by the **Scene Mode** setting:
+To copy or paste a scene, right-click on **Scene** buttons **A** or **B** to display the context menu, then select **Copy** or **Paste**.
 
--   **Single** – Notes will be played only by the selected scene.
--   **Key Split** – Notes below the **split key** will be played by scene A,
-    notes above and including the **split key** will be played by scene
-    B.
--   **Channel Split** – Notes from MIDI channels below and including the **split MIDI channel** will be played by scene A,
-    notes from MIDI channels strictly above the **split MIDI channel** will be played by scene B.
--   **Dual** – Both scenes will play all the notes.
+To select a **Scene Mode**, select:
 
-In both **Key Split** and **Dual** mode, if MPE is disabled, the system also supports MIDI channel routing where Channel 2 plays only
-Scene A and channel 3 plays only Scene B. MIDI channel 1 and all other channels higher than 3 play the Split/Dual mode.
+- **Single** to play only the selected scene A or B.
+- **Key Split** to play Scene A for notes below the **Split** key, and
+  Scene B for notes including and above the **Split** key.
+- **Channel Split** to play Scene A for channels below and including the
+  **Split** MIDI channel, and Scene B for channels above the **Split** MIDI channel.
+- **Dual** to play both scenes A and B.
 
-**Poly** shows the number of voices currently playing and allows you to
-set an upper limit to the number of voices allowed to play at the same
-time by dragging horizontally on the value. The voice-limiter will kill off excess voices gently to avoid
-audible artifacts, thus it's not uncommon for the voice count to exceed
-the limit.
+If you disable **MPE** and select **Scene Mode** **Key Split** or **Dual**, channel 1 and channels 4 to 15 play the selected **Scene Mode**. Channel 2 plays only Scene A and channel 3 plays only Scene B.
+
+### Polyphony limit
+
+If you try to play more voices than the polyphony limit allows, Surge XT will stop a playing voice to make room for the new one. To change how Surge stops voices at the polyphony limit, see [**Note Priority**](#other-sound-generation-parameters) and [**Play Mode**](#other-sound-generation-parameters) options.
+
+To change the polyphony limit, drag the **Poly** control up or down. **Poly** displays a count of playing voices.
 
 ## Patch Browser
 
 ![Illustration 9: Patch browser](/images/manual-xt/Pictures/patchbrowser.png)
 
+A modified or unsaved patch displays with an asterisk in the patch name area.
+
+**Note**: To deactivate the **Confirm Patch Loading** dialog, which protects you from losing unsaved changes, select **Don't ask me again** when the dialog displays. You can also toggle this from [the main menu](#main-menu) > [Workflow](#workflow) > **Confirm patch loading if unsaved changes exist**.
+
 ### Navigation
 
-Cycling through sounds in Surge XT is easy: just press the arrow buttons
-until you find something you like. If you left-click the patch-name
-field (anywhere in the white area), a menu will list all available
-patches arranged into categories. A right-click will bring up a menu with just the
-patches of the current category. If you middle-click on these buttons, a random patch
-will be loaded.
+To cycle through patches, select the **Patch** arrow buttons.
 
-These categories are also grouped into three sections depending on who created them:
+To cycle through patch categories, select the **Category** arrow buttons.
 
--   Factory Patches - Patches created in-house by the Surge XT authors.
+To select a random patch, middle-click the **Patch** or **Category** arrow buttons.
 
--   3<sup>rd</sup> party patches - Patches created by users and 3<sup>rd</sup> parties.
-    Categorized by creators.
+To select a patch in the current category, right-click the **Patch Browser** area where the patch name displays, then select a patch.
 
--   User Patches - Your own patches will be stored here. How you categorize them
-    is entirely up to you. At the top of this section is where your favorites patches will show up.
+To list all patches, select the **Patch Browser** area where the patch name displays. In the pop-up, patch categories display in columns: 
 
-At the bottom, there is an option to
-[download additional content](https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content).
+- **Factory Patches** were created by authors of Surge 1.6. Select a category, then a patch.
+- **Third Party Patches** were contributed by users and the Surge Synth Team. Select a creator name, then a category, then a patch.
+- **User Patches** are your own patches. You can choose how to categorize these patches.
+  **Favorites** are patches where you selected the **Favorite** heart icon.
 
-By default, to help prevent you loosing an unsaved patch by switching patches, a confirmation dialog will open, asking
-you if you still want to proceed. You can turn off this warning by checking the _Don't ask me again_ box, or by
-disabling the appropriate option in the [Workflow](#workflow) category found in the [main menu](#main-menu).
-A modified or unsaved patch name will show an asterisk in the patch name area.
+The patch browser also supports [MIDI program changes](#program-change-messages).
 
-You can also directly load patches (.fxp) by dragging and dropping them anywhere over the Surge XT interface.
+### Load more patches
 
-There is also an option in the patch menu to set the current patch as the default one to be loaded when
-opening a new instance of Surge XT.
+To directly load a `.fpx` patch file, drop it onto the Surge XT window.
 
-Furthermore, the patch menu allows you to rename or delete a patch. Those options will only appear if you have a
-non-factory patch loaded in the synth.
+To [download additional content](https://github.com/surge-synthesizer/surge-synthesizer.github.io/wiki/Additional-Content), select **Download Additional Content** from [the main menu](#main-menu) at the bottom-right of the window, or from the window context menu.
 
-Finally, the patch browser also support program changes via MIDI, which you can learn more about [here](#program-change-messages).
+### Managing patches
+
+To set the current patch as default when you open a new instance of Surge XT, select **Set Current Patch As Default** from the patch context menu.
+
+To rename a user patch, select **Rename** from the patch context menu.
+
+To delete a user patch, select **Delete** from the patch context menu.
 
 ### Searching Patches
 
-To search patches by name, simply click on the magnifier glass icon to the left of the patch name area.
-You may see Surge XT first update the patch database before being able to type in your search query.
+To search patches by name, select the magnifier glass icon to the left of the patch name area, then start entering text.
 
-You can also search for patches by **author** or **category** by typing "AUTHOR=" or "CATEGORY=", followed by
-your search query. There is also a shorthand for these keywords, you can type "AUTH=" or "CAT=" instead.
+**Note**: Surge XT might first take a moment to update its patch database.
 
-If the **Retain patch search results after loading** option is enabled in the [Workflow](#workflow) category found in
-the main menu, holding Ctrl while selecting your desired search result with your mouse or while pressing enter will
-close the search results.
+You can also search metadata:
+
+- To search by author, enter `AUTHOR=` or `AUTH=`, then part of the author name.
+- To search by category, enter `CATEGORY=` or `CAT=`, then part of the category name.
+
+By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain patch search results after loading**. To close the list with this enabled, press Ctrl while selecting a patch, or press Escape.
 
 ### The Save Dialog
 
+A modified or unsaved patch displays with an asterisk in the patch name area.
+
+To save a patch, select **Save**, or press Ctrl + S.
+
+**Hint**: To bypass the **Save** dialog when **Confirm Patch Loading** is enabled, hold Shift when confirming with **OK**.
+
+
 ![Illustration 10: Save dialog](/images/manual-xt/Pictures/store_dialog.png)
 
-Clicking the **Save** button of the patch browser opens the save dialog.
-This is where you name your new patch and choose which category it
-should belong in. You can also create a new category manually here as
-well. The patches you save will end up in the user section at the bottom
-of the patch menu. The save dialog also provides text fields for the name of the patch creator,
-license, and comments.
-
-Note: You can display the comments of a particular patch by hovering over the patch name area with your mouse.
-
-Holding down the **Shift** key when saving a patch will automatically overwrite an existing patch, which
-bypasses the dialog asking you for an overwrite confirmation.
+- Enter a **Name** for your new patch
+- Choose a **Category**, or start typing to list matching categories, or create a new category. Note: you can use subfolder categories, but these might be skipped by category navigation arrows.
+- Enter **Author** as you wish to be identified. 
+- Enter a **License** for how your patch may be used. For example, `Licensed under the maximally permissive CC0 license`.
+- Enter **Comments**. Comments display when you hover over the patch name.
 
 ### Favoriting Patches
 
-Adding a patch to your favorites list is as easy as pressing the heart icon to the right of the patch name area.
-Right-clicking on that same icon will allow you to access the favorite patches list.
+To favorite a patch, select the heart icon in patch name area.
+To load a favorite patch, right-click the heart icon to display the **Favorites** list and select a patch.
 
 ## Status Area
 
 ![Illustration 11: Status area](/images/manual-xt/Pictures/status.png)
 
-This area is meant to be a quick access to some of Surge XT's features that are also present in the Menu.
-(see [Main Menu](#main-menu))
+Select **MPE** to toggle MPE mode. Right-click to open a context menu of MPE settings.
 
-The **MPE** and **Tune** buttons are for quickly enabling/disabling those features in the current Surge XT instance.
-Right-clicking on one of these buttons will reveal more options which are also present in sub-menus under the Menu button as well.
-Left-clicking the Tune button while Surge XT is in its default tuning will also simply open the menu. See [Microtuning](#microtuning) for more information.
+Select **Tune** to toggle [custom tuning](#microtuning). If there is no custom tuning, this opens the **Tuning** context menu.
+
+Select **Zoom** to open the context menu and change the size of the Surge XT window, or set the default size for Surge XT.
+
+You can also access **MPE settings**, **Tuning**, and **Zoom** from [the main menu](#main-menu).
 
 ## FX Bypass, Character, Global Volume
 
 ![Illustration 12: FX bypass, character and global volume](/images/manual-xt/Pictures/fx_bypass.png)
 
-**FX Bypass** lets you quickly hear what a patch sounds like without the effect-units. (see [Effects](#effects))
+Select an effects type to deactivate:
+- **Off** activates all effects.
+- **Send** deactivates send effects.
+- **Send + Global** deactivates send and global effects.
+- **All** deactivates all effects.
 
--   **Off** – Bypass is disabled, all effects are active.
--   **Send** – The send effects are bypassed.
--   **Send + Global** - The send and global effects are bypassed.
--   **All** – All effects are bypassed.
+**Character** shapes the timbre of oscillators. Select **Warm**, **Neutral**, or **Bright**.
 
-**Character** controls the amount of high-frequency content present in
-most of Surge XT's oscillator algorithms. Available choices are Warm, Neutral
-and Bright.
+**Global Volume** is the final gain stage.
 
-**Global Volume** controls the last gain stage before the output.
-You can choose to hard clip the global output either at **+18 dBFS** (default) or **0 dBFS**
-by right-clicking on it.
+To change clipping of global output, right-click **Global Volume** then select a **Global Hard Clip** option from the context menu:
+
+- **At +18 dBFS** (default),
+- **At 0 dBFS**
+- **Disabled**
+
+**Warning**: Change **Global Hard Clip** with care. Loud sounds increase the risk of damaging equipment or hearing. You should also limit sounds in your DAW or downstream equipment. Take special care with feedback, effects, and resonance features.
 
 ### Level Meter
 
-The level meter above the global volume shows the output level, and will become red if it goes
-above 0 dBFS. If you right-click on the level meter, you will find options to open the [oscilloscope](#oscilloscope),
-and also to display CPU usage.
+The level meter displays the current output level. Levels above 0 dBFS display red.
+
+To open the [oscilloscope](#oscilloscope), press Alt + O, or right-click on the level meter and select **Oscilloscope**. The oscilloscope displays a waveform or a spectrum.
+
+To display CPU usage in the level meter, right-click on the level meter and select **Show CPU Usage**.

--- a/src/content/manual_xt/04-header.mdx
+++ b/src/content/manual_xt/04-header.mdx
@@ -10,7 +10,7 @@ order: 4
 
 In the header, you can select and manage patches, select scene modes, configure MPE, configure tuning, select zoom, bypass effects, and control and monitor output.
 
-## Scene Select and Scene Mode
+## Scene select and Scene Mode
 
 ![Illustration 8: Scene select and scene mode](/images/manual-xt/Pictures/scene_select.png)
 
@@ -62,7 +62,7 @@ To list all patches, select the **Patch Browser** area where the patch name disp
 
 The patch browser also supports [MIDI program changes](#program-change-messages).
 
-### Load more patches
+### Loading more patches
 
 To directly load a `.fpx` patch file, drop it onto the Surge XT window.
 
@@ -89,7 +89,7 @@ You can also search metadata:
 
 By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain patch search results after loading**. To close the list with this enabled, press Ctrl while selecting a patch, or press Escape.
 
-### The Save Dialog
+### The Save dialog
 
 A modified or unsaved patch displays with an asterisk in the patch name area.
 
@@ -106,7 +106,7 @@ To save a patch, select **Save**, or press Ctrl + S.
 - Enter a **License** for how your patch may be used. For example, `Licensed under the maximally permissive CC0 license`.
 - Enter **Comments**. Comments display when you hover over the patch name.
 
-### Favoriting Patches
+### Favoriting patches
 
 To favorite a patch, select the heart icon in the patch name area.
 To load a favorite patch, right-click the heart icon to display the **Favorites** list and select a patch.
@@ -145,7 +145,7 @@ To change clipping of global output, right-click **Global Volume** then select a
 
 **Warning**: Change **Global Hard Clip** with care. Loud sounds increase the risk of damaging equipment or hearing. You should also limit sounds in your DAW or downstream equipment. Take special care with feedback, effects, and resonance features.
 
-### Level Meter
+### Level meter
 
 The level meter displays the current output level. Levels above 0 dBFS display red.
 

--- a/src/content/manual_xt/04-header.mdx
+++ b/src/content/manual_xt/04-header.mdx
@@ -41,7 +41,7 @@ To change the polyphony limit, drag the **Poly** control up or down. **Poly** di
 
 A modified or unsaved patch displays with an asterisk in the patch name area.
 
-**Note**: To deactivate the **Confirm Patch Loading** dialog, which protects you from losing unsaved changes, select **Don't ask me again** when the dialog displays. You can also toggle this from [the main menu](#main-menu) > [Workflow](#workflow) > **Confirm patch loading if unsaved changes exist**.
+**Note**: To deactivate the **Confirm Patch Loading** dialog that protects you from losing unsaved changes, select **Don't ask me again** when the dialog displays. You can also toggle this from [the main menu](#main-menu) > [Workflow](#workflow) > **Confirm patch loading if unsaved changes exist**.
 
 ### Navigation
 
@@ -87,7 +87,7 @@ You can also search metadata:
 - To search by author, enter `AUTHOR=` or `AUTH=`, then part of the author name.
 - To search by category, enter `CATEGORY=` or `CAT=`, then part of the category name.
 
-By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain patch search results after loading**. To close the list with this enabled, press Ctrl while selecting a patch, or press Escape.
+By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain Patch Search Results After Loading**. To close the list with this enabled, press Ctrl while selecting a patch, or press Escape.
 
 ### The Save dialog
 

--- a/src/content/manual_xt/04-header.mdx
+++ b/src/content/manual_xt/04-header.mdx
@@ -108,7 +108,7 @@ To save a patch, select **Save**, or press Ctrl + S.
 
 ### Favoriting Patches
 
-To favorite a patch, select the heart icon in patch name area.
+To favorite a patch, select the heart icon in the patch name area.
 To load a favorite patch, right-click the heart icon to display the **Favorites** list and select a patch.
 
 ## Status Area
@@ -119,7 +119,7 @@ Select **MPE** to toggle MPE mode. Right-click to open a context menu of MPE set
 
 Select **Tune** to toggle [custom tuning](#microtuning). If there is no custom tuning, this opens the **Tuning** context menu.
 
-Select **Zoom** to open the context menu and change the size of the Surge XT window, or set the default size for Surge XT.
+Select **Zoom** to open the context menu and change the size of the Surge XT window, or set its default size.
 
 You can also access **MPE settings**, **Tuning**, and **Zoom** from [the main menu](#main-menu).
 

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -205,11 +205,11 @@ additional options related to mono notes:
     -   **Sustain pedal allows note off retrigger** - If sustain is engaged and multiple notes are hit then held one after
         the other, Surge XT will switch to the previous note when the latest note is released.
 
-## Sound Shaping
+## Sound shaping
 
 ![Illustration 15: Sound shaping](/images/manual-xt/Pictures/sound_shaping.png)
 
-### Filter Controls
+### Filter controls
 
 **Filter Block Configuration** – Chooses how the filters, waveshaper and
 the gain stage are connected together. Note that only the Stereo and Wide configurations
@@ -244,7 +244,7 @@ will output a stereo signal.
 back into the input of the filter block. It has no effect when using filter
 block configurations without a feedback path.
 
-Note:
+**Note**:
 Be careful with your monitoring volume when using feedback. It's easy to
 make really loud high-pitched noises by mistake if you're not familiar
 with how the synth reacts to feedback.
@@ -299,7 +299,7 @@ follow filter 1's resonance slider setting.
 cutoff frequency of the filter. A setting of 100% means the filter
 frequency will follow the pitch harmonically.
 
-### Envelope Generators
+### Envelope generators
 
 There are two envelope generators connected to the filter block.
 
@@ -356,7 +356,7 @@ at different input levels, which can be controlled with the waveshaper's **Drive
 
 ![Illustration 21: Waveshaper analysis](/images/manual-xt/Pictures/waveshaper_analysis.png)
 
-### Other Sound Shaping Parameters
+### Other sound shaping parameters
 
 **Keytrack root note** – Sets the root key of the filter keytracking and the
 keytrack modulation source. At the root key, the keytrack modulation

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -79,16 +79,17 @@ Other controls are specific to each [oscillator type](#oscillator-algorithms).
 
 The mixer controls six channels, and a **Pre-filter Gain**:
 
-- **Oscillator 1**, **Oscillator 2**, **Oscillator 3**.
-- **Ring Modulation of 1 &times; 2**, **Ring Modulation of 2 &times; 3**.
+- **Oscillator 1**
+- **Oscillator 2**
+- **Oscillator 3**
+- **Ring Modulation of 1 &times; 2**
+- **Ring Modulation of 2 &times; 3**
 - **Noise Oscillator**
 
-Surge XT uses **digital ring modulation**, multiplying the raw output of two oscillators.
+Surge XT uses 'digital ring modulation', multiplying the raw output of two oscillators.
 
 To choose a ring modulation mode, right-click a slider, and select **Ring Modulation**,
 **Continuous XOR**, or **Scale-Invariant Linear Modulation** types 1 to 9.
-
-**Hint**: Experiment with the ring modulation options.
 
 You can also [apply ring modulation to the pair of filter outputs](#filter-controls) with **Filter Configuration** > **Ring**.
 
@@ -112,7 +113,7 @@ To select which filters a channel routes to, select from the group of three boxe
 
 **Notes**:
 - If you set **Filter Configuration** to **S1**, **S2**, **S3**, or **Wide**, then any output from filter 1 then routes to filter 2, so **Left** or **Center** routes pass through both filters in turn.
-- If you set **Filter Configuration** to **Ring**, only the **Center** route results in sound from the filter section.
+- If you set **Filter Configuration** to **Ring**, then you need to route some sound to each filter.
 
 ### Other sound generation parameters
 

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -4,158 +4,158 @@ slug: scene-controls
 order: 5
 ---
 
-# Scene Controls
+# Scene controls
 
-The UI of the scene section can also be further divided into two parts:
-
--   Sound generation
--   Sound shaping
-
-The sound is generated and mixed in the sound generation section. After that, it
-goes through the sound shaping section.
+Sound is generated then shaped.
 
 ![Illustration 13: Scene controls](/images/manual-xt/Pictures/scene_sections.png)
 
-## Sound Generation
+## Sound generation
 
-This is where the sound is born. The oscillators generate waveforms
-according to the notes played. They are then summed up in the mixer.
+When you play a note, oscillators generate waveforms and send them to the mixer.
 
 ![Illustration 14: Sound generation](/images/manual-xt/Pictures/sound_generation.png)
 
 ### Oscillators
 
-**1/2/3-buttons** – Chooses the active oscillator for editing. You can right-click on one of them
-and a context menu with the name, **Copy** and **Copy (with modulation)** options will show up.
+To display an oscillator for editing, select **Oscillator** buttons **1**, **2**, or **3**.
+If the oscillator is muted in the [mixer](#mixer), the waveform displays dimmed.
 
-**Display** – Shows the active waveform. When the **Wavetable** or **Window** oscillator
-is used, it will also work as wavetable selector by clicking on the orange bar or on the straight arrow buttons
-to cycle through them. When the selected oscillator in the display is muted, the waveform will be semi-transparent.
+To copy an oscillator, right-click **1**, **2**, or **3**, then select **Copy** or **Copy with modulation** from the context menu.
 
-**Type** – Oscillator type. Chooses which algorithm is used for the
-oscillator. Available options are:
+To change [oscillator algorithm](#oscillator-algorithms), select the drop-down list at the bottom-right of the oscillator area:
 
--   Classic
--   Modern
--   Wavetable
--   Window
--   Sine
--   FM2
--   FM3
--   String
--   Twist
--   Alias
--   S&H Noise
--   Audio Input.
+- Classic
+- Modern
+- Wavetable
+- Window
+- Sine (default)
+- FM2
+- FM3
+- String
+- Twist
+- Alias
+- S&H Noise
+- Audio Input.
 
-See [Oscillators](#oscillator-algorithms) in the Technical Reference section for more information.
+To select a wavetable with **Wavetable** or **Window** oscillators, select the wavetable name or its arrow buttons, or
+you can right-click to select within the current wavetable category.
 
-**Pitch & Octave** – Controls the pitch for this particular oscillator.
-Its context menu can be used to extend its range, or to set the pitch to **Absolute** mode, which makes the pitch shift
-in absolute frequency as opposed to relative to the note that is being played.
+#### Pitch
 
-**Keytrack** – When disabled, the oscillator will play the same pitch
-regardless of the key pressed. This button can be right-clicked to toggle its state across all
-oscillators in the scene.
+**Pitch & Octave** control the pitch for the oscillator.
 
-**Retrigger** – If active, the oscillator and all its unison voices will always start immediately
-at the same phase position. This is useful for snappy sounds where you want the
-attack to sound exactly the same each note. This button can be right-clicked to set its state across all
-oscillators in the scene.
+To extend the range of the **Pitch** control, select **Extend Range** from the context menu.
 
-**Other** - The rest of the sliders from the oscillator editor are specific to each
-oscillator type. See [Oscillators](#oscillator-algorithms) in the
-Technical Reference section for more information.
+To select a pitch offset in Hz, instead of a semitone (note degree) offset, select **Absolute** from the context menu.
+
+#### Keytrack
+
+To toggle key tracking for the oscillator, select or unselect **Keytrack**.
+When unselected, the oscillator plays at a fixed pitch that is the same for all notes.
+
+To toggle key tracking for all oscillators, right-click **Keytrack** then select **Enable Keytrack For All Oscillators** or
+**Disable keytrack for all oscillators**.
+
+#### Retrigger
+
+To toggle retriggering for the oscillator, select or unselect **Retrigger**.
+When active, each voice starts with the oscillator and all its unison voices at the same phase position.
+
+To toggle retriggering for all oscillators, right-click **Retrigger** then select **Enable Retrigger For All Oscillators** or
+**Disable Retrigger For All Oscillators**.
+
+**Hint**:
+When you enable **Retrigger**, each note onset sounds more consistent or 'snappy'.
+When you disable **Retrigger**, the onset can sound more varied and less 'digital'.
+
+#### Other oscillator controls
+
+Other controls are specific to each [oscillator type](#oscillator-algorithms).
 
 ### Mixer
 
-#### Mixer Channels
+#### Mixer channels
 
-Excluding the **Pre-filter Gain** (slider on the right), the Mixer has 6 channels (sources) from left to right:
+The mixer controls six channels, and a **Pre-filter Gain**:
 
--   **Oscillators 1, 2, 3**
+- **Oscillator 1**, **Oscillator 2**, **Oscillator 3**.
+- **Ring Modulation of 1 &times; 2**, **Ring Modulation of 2 &times; 3**.
+- **Noise Oscillator**
 
--   **Ring Modulation of 1x2, 2x3** – The source of these two channels is **digital ring modulation** from the oscillators.
-    This type of RM is a bit different from the traditional carrier-modulator style ring modulation.
-    Digital ring modulation is simply the result of multiplying the output of oscillators 1 and 2,
-    or 2 and 3.
+Surge XT uses **digital ring modulation**, multiplying the raw output of two oscillators.
 
-    There are different options for both ring modulation sources. A **Continuous XOR** mode can be enabled, a feature that can be
-    found in some of today's modular synthesizers.
+To choose a ring modulation mode, right-click a slider, and select **Ring Modulation**,
+**Continuous XOR**, or **Scale-Invariant Linear Modulation** types 1 to 9.
 
-    In addition, there are some more experimental **Scale-Invariant Linear Modulation** options. These are the result of measuring
-    the relative differences between samples of the ring modulation inputs, and applying those on differnt mathematical dimensions.
-    Since the theory behind this concept is difficult to illustrate and explain, trying to apply diffent types and hearing the results
-    is recommended.
+**Hint**: Experiment with the ring modulation options.
 
--   **Noise Oscillator**
+You can also [apply ring modulation to the pair of filter outputs](#filter-controls) with **Filter Configuration** > **Ring**.
 
-#### Channel Parameters
+#### Channel parameters
 
-Each channel has the following controls:
+To change gain for a channel, move its [slider](#sliders-and-controls).
 
--   **M** – Mute. You can of course have multiple channels muted at the same time, but you can also keep only the channel
-    you mute muted by holding down **Ctrl / Cmd** and clicking on the desired mute switch.
+To mute a channel, select **M**. Select again to unmute.
 
--   **S** – Solo (only play channels that have solo active). You can have multiple channels in solo at the same time, or
-    only one at a time by holding down **Ctrl / Cmd** and clicking on the desired solo switch.
+To mute a channel and unmute the other channels, hold Ctrl and select **M**.
 
--   **Triple Orange Box** (Filter routing) – Chooses which filter the channel is routed to.
-    The left position routes the channel output to filter 1, the right position
-    routes it to filter 2, while the middle position, which is selected
-    by default, routes it to both.
-    However, this setting will only route the channel output to filter
-    1 if a **serial** filter block configuration is used, since the
-    audio will then go through the second one in the filter block anyways.
-    If any other configuration than serial is used, the audio will then
-    be routed to both filters, as expected.
+To solo a channel, select **S**. Select **S** again to unsolo. If any channel has solo enabled, then the mixer ignores all mutes.
 
--   **Slider** – Gain control for each input.
+To solo a channel and unsolo the other channels, hold Ctrl and select **S**.
 
-### Other Sound Generation Parameters
+To select which filters a channel routes to, select from the group of three boxes:
 
-**Pitch & Octave** – Controls the pitch for the entire scene. Affects
-the filter key-tracking and the keytrack modulation source as well. The
-range of the slider can be extended using the context menu.
+- **Left** routes the channel output to filter 1.
+- **Center** routes the channel output to filters 1 and 2.
+- **Right** routes the channel output to filter 2.
 
-**Portamento** – Portamento is when a new note will slide in
-pitch from the pitch of the last played note. This setting determines how
-long the slide will be. A setting of 0 disables Portamento. This parameter can be
-tempo-synced.
+**Notes**:
+- If you set **Filter Configuration** to **S1**, **S2**, **S3**, or **Wide**, then any output from filter 1 then routes to filter 2, so **Left** or **Center** routes pass through both filters in turn.
+- If you set **Filter Configuration** to **Ring**, only the **Center** route results in sound from the filter section.
 
-Portamento has some interesting options accessible in its context menu:
+### Other sound generation parameters
 
--   **Constant rate** - If this option is enabled, the time to cover **one octave** is
-    defined by the Portamento slider value. From there on, gliding between 2 octaves
-    for instance will take twice as long, and so on.
-    By default, this option is disabled, so the **glide rate**
-    is proportional to the distance between the two keys, making it so that it
-    always takes the same time to glide between **any two keys**.
--   **Glissando** - If this option is enabled, the pitch slide will be quantized
-    to the scale degrees.
--   **Retrigger at scale degrees** - If this option is enabled, the FEG and AEG
-    (see [Envelope Generators](#envelope-generators)) will be triggered each time the portamento
-    slide crosses a scale degree.
--   **Curve options** - You can choose between a **Logarithmic**, **Linear** or **Exponential**
-    portamento curve. By default, the portamento slide follows a linear curve.
+#### Scene pitch and octave
 
-**Osc Drift** – Applies a small amount of instability to the pitch of
-all oscillators, making them subtly detuned. Although the parameter is
-shared, the randomness of the instability effect is independent for all
-oscillators and all the unison voices of each oscillator. By right-clicking
-on this control, you can choose to also randomize the pitch at the very start of
-the note by enabling the **Randomize initial drift phase** option.
+To offset the pitch of the scene, move the **Pitch** slider.
+To offset the pitch of the scene by whole octaves, select a **Scene** **Octave** from -3 to +3.
 
-**Noise Color** – Affects the frequency spectrum of the noise
-generator. The middle position results in white noise. Moving the slider
-to the left emphasizes low frequencies while moving it to the right emphasizes high frequencies.
+**Note**: Scene pitch parameters add to keytrack values used by **Filter 1 Keytrack**, **Filter 2 Keytrack**, and to the **Keytrack** modulation source.
 
-**Bend Depth** – Pitch Bend Depth Up/Down. Controls the range of the
-pitch bend wheel, in semitones.
+#### Portamento
 
-This control can be extended with the dedicated option in its context menu. It enables
-type-ins of fractions and cents for configuring microtonal pitch-bends of arbitrary size within the range
-of 24 semitones.
+To change the time for pitch to change from one note to the next, move the **Portamento** slider.
+
+From the **Portamento** context menu:
+- To sync portamento time with the tempo, select **Tempo Sync**.
+- To make portamento change pitch at a constant rate, enable **Constant rate**. Portamento is then the time to move over one octave. When **Constant rate** is disabled, portamento time is the same for all notes.
+- To quantize portamento to pitch degrees (semitones), enable **Glissando**.
+- To retrigger [envelope generators](#envelope-generators) (FEG and AEG) as pitch crosses scale degrees, enable **Retrigger at scale degrees**.
+- To change the portamento curve, select **Curve options**, then **Logarithmic**, **Linear** (default) or **Exponential**.
+
+#### Osc drift
+
+To independently vary the pitch of all oscillators and their unison voices, enable **Osc Drift**.
+
+To also randomize the pitch at the very start of the note, right-click and enable **Randomize initial drift phase**.
+
+#### Noise color
+
+To shape the timbre of the noise generator, move the **Noise Color** slider:
+
+- Low frequencies to the left
+- White noise in the middle
+- High frequencies to the right.
+
+#### Bend depth
+
+To control the pitch wheel range, from 0 to 24 semitones:
+- left-click **Bend Depth** > **Down** or **Bend Depth > Up**, and then drag up or down.
+- hover over **Bend Depth** > **Down** or **Bend Depth > Up**, and use the scroll wheel.
+- right-click **Bend Depth** > **Down** or **Bend Depth > Up**, select **Edit value** from the context menu, and enter a value. You can also enter decimal numbers, fractions, and cents.
+
+#### Play mode
 
 **Play Mode** – Chooses how multiple notes are handled. Poly will allow
 multiple notes to be played simultaneously, while Mono will only let the last note

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -136,7 +136,7 @@ From the **Portamento** context menu:
 - To retrigger [envelope generators](#envelope-generators) (FEG and AEG) as pitch crosses scale degrees, enable **Retrigger at scale degrees**.
 - To change the portamento curve, select **Curve options**, then **Logarithmic**, **Linear** (default) or **Exponential**.
 
-#### Osc drift
+#### <a name="osc-drift"></a>Oscillator drift
 
 To independently vary the pitch of all oscillators and their unison voices, enable **Osc Drift**.
 

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -111,38 +111,34 @@ To select which filters a channel routes to, select from the group of three boxe
 - **Center** routes the channel output to filters 1 and 2.
 - **Right** routes the channel output to filter 2.
 
-**Notes**:
-- If you set **Filter Configuration** to **S1**, **S2**, **S3**, or **Wide**, then any output from filter 1 then routes to filter 2, so **Left** or **Center** routes pass through both filters in turn.
-- If you set **Filter Configuration** to **Ring**, then to hear sound, you need to route some sound to each filter.
-- If you set **Filter Configuration** to **Wide**, then *Left* and *Right* routes are hard-panned to stereo positions.
+See also: [filter configuration](#filter-configuration).
 
-### Other sound generation parameters
-
-#### Scene pitch and octave
+### <a name="other-sound-generation-parameters"></a>Scene pitch and octave
 
 To offset the pitch of the scene, move the **Pitch** slider.
 To offset the pitch of the scene by whole octaves, select a **Scene** **Octave** from -3 to +3.
 
 **Note**: Scene pitch parameters add to keytrack values used by **Filter 1 Keytrack**, **Filter 2 Keytrack**, and to the **Keytrack** modulation source.
 
-#### Portamento
+### Portamento
 
 To change the time for pitch to change from one note to the next, move the **Portamento** slider.
 
 From the **Portamento** context menu:
+
 - To sync portamento time with the tempo, select **Tempo Sync**.
 - To make portamento change pitch at a constant rate, enable **Constant rate**. Portamento is then the time to move over one octave. When **Constant rate** is disabled, portamento time is the same for all notes.
 - To quantize portamento to pitch degrees (semitones), enable **Glissando**.
 - To retrigger [envelope generators](#envelope-generators) (FEG and AEG) as pitch crosses scale degrees, enable **Retrigger at scale degrees**.
 - To change the portamento curve, select **Curve options**, then **Logarithmic**, **Linear** (default) or **Exponential**.
 
-#### <a name="osc-drift"></a>Oscillator drift
+### <a name="osc-drift"></a>Oscillator drift
 
 To independently vary the pitch of all oscillators and their unison voices, enable **Osc Drift**.
 
 To also randomize the pitch at the very start of the note, right-click and enable **Randomize initial drift phase**.
 
-#### Noise color
+### Noise color
 
 To shape the timbre of the noise generator, move the **Noise Color** slider:
 
@@ -150,60 +146,51 @@ To shape the timbre of the noise generator, move the **Noise Color** slider:
 - White noise in the middle
 - High frequencies to the right.
 
-#### Bend depth
+### Bend depth
 
 To control the pitch wheel range, from 0 to 24 semitones:
 - left-click **Bend Depth** > **Down** or **Bend Depth > Up**, and then drag up or down.
 - hover over **Bend Depth** > **Down** or **Bend Depth > Up**, and use the scroll wheel.
 - right-click **Bend Depth** > **Down** or **Bend Depth > Up**, select **Edit value** from the context menu, and enter a value. You can also enter decimal numbers, fractions, and cents.
 
-#### Play mode
+### Play mode
 
-**Play Mode** – Chooses how multiple notes are handled. Poly will allow
-multiple notes to be played simultaneously, while Mono will only let the last note
-play. Latch will continuously play the last played note (mono).
+To select a play mode, select from the **Play Mode** group, or right-click and select from the context menu.
 
-Mono has two possible modifiers:
+- **Poly** mode lets you to play many notes at the same time, up to the [polyphony limit](polyphony-limit).
+- **Mono** modes only play one note, which depends on [note priority](note-priority). By default, the latest note has priority.
+- **Latch** mode plays the latest note continuously without releasing.
 
--   **Single Trigger EG (ST)** means that the two envelope generators are
-    not restarted when sliding between two notes (two notes that overlap
-    in time)
--   **Fingered Portamento (FP)** means that portamento is only applied when
-    sliding between notes and not when there is time between the played
-    notes.
+#### Poly play mode
 
-When **Play Mode** is set to one of the Poly modes, the context menu of that button list will display
-additional options related to the voice allocation for a key:
+With **Play Mode** set to **Poly**:
 
--   **Stack Multiple** - Selected by default. Surge XT will play the replayed note on a new voice, in a cyclic manner
-    known as round-robin.
--   **Reuse Single** - Selecting this option will make Surge XT allocate the replayed note to the same voice with which
-    that note was previously played.
+- To use a new voice for a replayed note, select **Stack Multiple**. This is also known as 'round robin', and is the default.
+- To reuse a voice that is already playing the same note as your new note, select **Reuse Single**.
 
-When **Play Mode** is set to one of the Mono modes, the context menu of that button list will display
-additional options related to mono notes:
+#### Mono play modes
 
--   **Note Priority**
+- **Mono** mode plays only the latest note.
+- **Mono (ST)** or **Mono (Single Trigger)** mode does not retrigger the envelope generators when sliding between two overlapping notes.
+- **Mono (FP)** or **Mono (Fingered Portamento)** mode applies portamento only between overlapping notes.
+- **Mono (ST+FP)** or **Mono (Single Trigger & Fingered Portamento)** combines **Mono (ST)** and **Mono (FP)** modes.
 
-    -   **Last note priority** - Will play the latest note when multiple notes are played together
-    -   **High note priority** - Will play the highest note when multiple notes are played together
-    -   **Low note priority** - Will play the lowest note when multiple notes are played together
-    -   **Legacy note priority** - When multiple notes are played together, it will play the latest note once hit and play
-        the highest remaining note once released.
+To set <a name="note-priority"></a>note priority, right-click the **Play Mode** area and select one of: 
 
--   **Envelope Retrigger Behavior**
+- **Last** to play the latest note only. When released, play the latest remaining note. This is the default option.
+- **High** to play the highest note only. When released, play the highest remaining note.
+- **Low** to play the lowest note only. When released, play the lowest remaining note.
+- **Legacy** to play the latest note. When released, play the highest remaining note.
 
-    -   **Reset to zero** - Selected by default. The envelopes will immediately reset to the beginning of the attack stage
-        when pressing a note.
-    -   **Continue from current level** - Selecting this option will make the envelopes start at the level they were left
-        off from the previous note.
+To set <a name="envelope-retrigger-behavior"></a>envelope retrigger behavior, right-click the **Play Mode** area and select one of: 
 
--   **Sustain pedal in mono mode**
-    -   **Sustain pedal holds all notes (no note off retrigger)** - If sustain is engaged and multiple notes are hit then
-        held one after the other, Surge XT will stay on the latest note when releasing that note instead of switching to the
-        previous note.
-    -   **Sustain pedal allows note off retrigger** - If sustain is engaged and multiple notes are hit then held one after
-        the other, Surge XT will switch to the previous note when the latest note is released.
+- **Reset To Zero** to reset evenelopes to the beginning of the attack stage when you start a note. This is the default option.
+- **Continue From Current Level** to make envelopes continue from the level of the previous note.
+
+To set <a name="sustain-pedal-mono"></a>behavior when the sustain pedal is pressed in mono mode, right-click the **Play Mode** area, select **Sustain pedal in mono mode**, then select one of: 
+
+- **Sustain pedal holds all notes (no note off retrigger)** to stay on the priority note when you release that note. This is the default option.
+- **Sustain pedal allows note off retrigger** to switch to the remaining priority note when you release the priority note.
 
 ## Sound shaping
 
@@ -211,49 +198,41 @@ additional options related to mono notes:
 
 ### Filter controls
 
-**Filter Block Configuration** – Chooses how the filters, waveshaper and
-the gain stage are connected together. Note that only the Stereo and Wide configurations
-will output a stereo signal.
+To select how the filters, waveshaper, and gain stage connect together, select a **Filter Configuration**:
 
--   **Serial 1** - The signal from the Mixer goes into Filter 1, then into the Waveshaper, then into Filter 2, then the
-    Amplifier which contains the Amplifier Envelope Generator (AEG), before going through the Scene Highpass and to the final
-    Scene Output section.
+- **Serial 1** routes the signal from the Mixer goes into Filter 1, then into the Waveshaper, then into Filter 2, then the
+  Amplifier which contains the Amplifier Envelope Generator (AEG), before going through the Scene Highpass and to the final
+  Scene Output section.
+- **Serial 2** is the same as with **Serial 1**, plus a feedback path from the
+  output of the Amplifier back into Filter 1.
+- **Serial 3** is the same as with **Serial 2**, but Filter 2 is in the feedback loop, which is after
+  the signal tap from the Amplifier instead of before.
+- **Dual 1** routes the signal from the Mixer to both Filter 1 and Filter 2 in parallel. The outputs from both filters are
+  summed, then sent to the Waveshaper, then into the Amplifier, and finally in the Scene Highpass before the Scene Output section. Feedback is again tapped at the output of the Amplifier and goes back into both filters (it's summed with the output from the Mixer).
+- **Dual 2** is the same as with **Dual 1**, except the Waveshaper is only applied to Filter 1
+  before its output is summed with the output from Filter 2.
+- **Stereo** is the same as with **Dual 1**, except Filter 1 is always on the left channel and
+  Filter 2 is always on the right channel.
+- **Ring** is the same as with **Dual 1**, except the outputs from Filter 1 and Filter 2 are multiplied
+  (ring modulated) together instead of being summed before the Waveshaper.
+- **Wide** is the same as with **Serial 2**, except it's doubled for a full stereo signal path.
 
--   **Serial 2** - The signal path is the same as with **Serial 1**, with the addition of a feedback path going from the
-    output of the Amplifier back into Filter 1.
+**Notes**:
+- Only **Stereo** and **Wide** output a stereo signal.
+- If you set **Filter Configuration** to **S1**, **S2**, **S3**, or **Wide**, then any output from filter 1 then routes to filter 2, so **Left** or **Center** routes pass through both filters in turn.
+- If you set **Filter Configuration** to **Ring**, then to hear sound, you need to route some sound to each filter.
+- If you set **Filter Configuration** to **Wide**, then *Left* and *Right* routes are hard-panned to stereo positions.
 
--   **Serial 3** - The signal path is the same as with **Serial 2**, but Filter 2 is in the feedback loop, which is after
-    the signal is being tapped from the Amplifier instead of before.
+#### Feedback
 
--   **Dual 1** - The signal from the Mixer is sent to both Filter 1 and Filter 2 in parallel. The outputs from both filters are
-    then summed, then sent to the Waveshaper, then into the Amplifier, and finally in the Scene Highpass before the Scene Output section.
-    Feedback is again tapped at the output of the Amplifier and goes back into both filters (it is summed with the output from the Mixer).
+To set the amount (and polarity) of output fed back into the input of the filter block, move the **Feedback** slider. It has no effect for **Serial 1**, because that configurations has no feedback path.
 
--   **Dual 2** - The signal path is the same as with **Dual 1**, except that the Waveshaper is only applied to Filter 1
-    before its output is summed with the output from Filter 2.
-
--   **Stereo** - The signal path is the same as with **Dual 1**, except that Filter 1 is always on the left channel and
-    Filter 2 is always on the right channel.
-
--   **Ring** - The signal path is the same as with **Dual 1**, except that the outputs from Filter 1 and 2 are multiplied
-    (ring modulated) together instead of being summed before continuing onwards to the Waveshaper.
-
--   **Wide** - The signal path is the same as with **Serial 2**, except it is being doubled for a full stereo signal path.
-
-**Feedback** – Controls the amount (and polarity) of output that's fed
-back into the input of the filter block. It has no effect when using filter
-block configurations without a feedback path.
-
-**Note**:
-Be careful with your monitoring volume when using feedback. It's easy to
+**Warning**: Be careful with your monitoring volume when using feedback. It's easy to
 make really loud high-pitched noises by mistake if you're not familiar
-with how the synth reacts to feedback.
+with how Surge XT processes feedback.
 
-Don't let this scare you though. There's a lot to be gained from proper
-and creative use of feedback. Changing the character of filters, making
-filters interact together, making basic physical models, making sounds
-that are just about to break apart. It is these things that make
-Surge XT truly special.
+**Hint**: Feedback is a creative technique that helps you change the character of filters, make
+filters interact together, create basic physical models, or make unstable sounds.
 
 **Filter Balance** – Controls how the two filters are mixed. The
 behavior depends on the filter block configuration.

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -113,7 +113,8 @@ To select which filters a channel routes to, select from the group of three boxe
 
 **Notes**:
 - If you set **Filter Configuration** to **S1**, **S2**, **S3**, or **Wide**, then any output from filter 1 then routes to filter 2, so **Left** or **Center** routes pass through both filters in turn.
-- If you set **Filter Configuration** to **Ring**, then you need to route some sound to each filter.
+- If you set **Filter Configuration** to **Ring**, then to hear sound, you need to route some sound to each filter.
+- If you set **Filter Configuration** to **Wide**, then *Left* and *Right* routes are hard-panned to stereo positions.
 
 ### Other sound generation parameters
 


### PR DESCRIPTION
The first PR of this content was accidentally deleted, so this was re-created from my backups. Apologies for any confusion.

# Notes on style update for Surge XT manual, chapter 04

## Style notes
- For consistency with the UI, we should stay with "enable"/"disable". Ideally, we'd change both docs and UI to use inclusive language "activate"/"deactivate".

## Decisions
- I've added a warning to **Global Hard Clip...** options. We should remove it if this could get us into legal trouble for steps that might still be unsafe.
  > **Warning**: Change **Global Hard Clip** with care. Loud sounds increase the risk of damaging equipment or hearing. You should also limit sounds in your DAW or downstream equipment. Take special care with feedback, effects, and resonance features.
- Text "Main Menu" doesn't appear in the UI, so we should call it "the main menu". "Menu" does, but "Menu" is ambiguous.

## Docs todos (copied into #348)
- Patch browser screenshot needs update, to show the Undo UI.
- Save dialog screenshot needs update, to show "Store tuning in patch"
- Cross-reference MPE things (Dual/split, Status button, main menu).
- Some cross-references (in Polyphony limit) should jump more precisely to related content. Use custom anchors, or create lower-level headings.
- "Surge XT is best used..." is passive. Make active.