### PR TITLE
CSS fixes for manual-xt

### DIFF
--- a/src/components/page.astro
+++ b/src/components/page.astro
@@ -4,7 +4,7 @@ import PageTitle from "@components/page_title.astro";
 ---
 
 <div class="flex place-content-center">
-    <div class="flex max-w-[100ch] flex-col gap-8 p-4 sm:p-8" id="pagecontent">
+    <div class="flex max-w-[100ch] flex-col gap-2 p-4 sm:p-8" id="pagecontent">
         <PageTitle title={title} />
         <slot />
     </div>

--- a/src/css/manual.css
+++ b/src/css/manual.css
@@ -23,4 +23,15 @@
     h4 {
         @apply text-xl;
     }
+    ul {
+        @apply list-outside list-disc;
+        margin-left: 1.6rem;
+        margin-bottom: 0.6rem;
+    }
+    p img {
+        margin: 0.4rem 0;
+    }
+    a {
+        text-decoration: underline;
+    }
 }


### PR DESCRIPTION
With side effect of slightly reducing spacing on some of the other pages.

We can move these higher up the style hierarchy later, to impact more pages - I wanted to limit scope of the change for now.

Should look like this (using content from the other content PRs)
![image](https://github.com/surge-synthesizer/surge-synthesizer.github.io/assets/13245475/51ac9919-ba42-43aa-942a-33f4b08fd422)
