### PR TITLE
Add filter-configuration anchor to support docs and app links

### DIFF
--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -196,7 +196,7 @@ To set <a name="sustain-pedal-mono"></a>behavior when the sustain pedal is press
 
 ![Illustration 15: Sound shaping](/images/manual-xt/Pictures/sound_shaping.png)
 
-### Filter Controls
+### <a name="filter-configuration"></a>Filter Controls
 
 To select how the filters, waveshaper, and gain stage connect together, select a **Filter Configuration**:
 


### PR DESCRIPTION
In response to bug-report https://discord.com/channels/744319641211633774/744320274714984518/1229224786954158091

Added an anchor to ensure legacy app and in-doc links work. The <a ...> tag will pass through the content render.