### PR TITLE
Minor fixes/improvements to Surge XT user manual

### DIFF
--- a/src/content/manual_xt/01-getting_started.mdx
+++ b/src/content/manual_xt/01-getting_started.mdx
@@ -23,7 +23,7 @@ For tutorials, tips, and more content, see the [Surge wiki](https://github.com/s
 
 To ask questions, report bugs or issues, or help develop Surge XT, visit the [Surge Synth Team Discord server](https://discord.com/invite/spGANHw).
 
-Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI, and Windows keyboard labels.
+Most of the images and descriptions use the default **Classic** skin, and this manual uses macOS conventions (**Title Case**) for labels in the UI. The names of modifier keys are often shown together for PC/Mac respectively, i.e. Ctrl/Command or Alt/Option, although parts of this manual may just use PC keyboard labels.
 
 Trademarks:
 

--- a/src/content/manual_xt/02_installing_or_building.mdx
+++ b/src/content/manual_xt/02_installing_or_building.mdx
@@ -75,7 +75,7 @@ The distribution package is built on Ubuntu 18.04.
 
 A list of required packages is listed in the source and in the deb file.
 
-**Note:** You can use alternative gestures Alt + Drag or the scroll wheel, which can conflict with the desktop
+**Note:** You can use alternative gestures Alt/Option + Drag or the scroll wheel, which can conflict with the desktop
 environment. To solve that issue, disable the global gesture in the desktop environment.
 
 
@@ -106,9 +106,9 @@ The Surge XT installer never changes files the user area, so save your files the
 
 ### Windows
 
-The patch library and wavetables are at `C:ProgramData\Surge XT`.
+The patch library and wavetables are at `C:\ProgramData\Surge XT`.
 
-The user patches are at `C:\Users\your username\My Documents\Surge XT`.
+The user patches are at `C:\Users\your username\Documents\Surge XT`.
 
 ### macOS
 
@@ -128,4 +128,4 @@ or change the user default settings for the first time.
 
 Surge XT is best used with a [DAW](https://en.wikipedia.org/wiki/Digital_audio_workstation), or a physical device
 like a keyboard. To get started, you can open the virtual keyboard from the main menu > **Workflow** > **Virtual Keyboard**,
-or Alt + K. See [Workflow](#workflow).
+or Alt/Option + K. See [Workflow](#workflow).

--- a/src/content/manual_xt/03-user-interface-basics.mdx
+++ b/src/content/manual_xt/03-user-interface-basics.mdx
@@ -41,13 +41,13 @@ Slider movement:
 
 - **Left-drag** moves the slider
 - **Shift + Left-drag** moves the slider with fine control
-- **Ctrl/Cmd + Left-drag** moves the slider in steps
+- **Ctrl/Command + Left-drag** moves the slider in steps
 - **Scroll Wheel** moves the slider 10% of its range
 - **Shift + Scroll Wheel** moves the slider in small steps
 
 Other slider actions:
 
-- If you have Alt pressed when you release a left-drag, the slider snaps back to its initial position
+- If you have Alt/Option pressed when you release a left-drag, the slider snaps back to its initial position
 - **Double Left-click** resets the parameter to its default value
 - **Right-click** displays the context menu
 - **Hover** displays its value
@@ -56,8 +56,8 @@ Other slider actions:
 ### Undo and Redo
 
 To undo or redo your latest changes, select the curved arrow buttons to the left of the **Save** button
-below the [Patch Browser](#patch-browser). You can also press Ctrl + Z to undo,
-and Ctrl + Y to redo.
+below the [Patch Browser](#patch-browser). You can also press Ctrl/Command + Z to undo,
+and Ctrl/Command + Y to redo.
 
 ### Parameter Context Menu
 
@@ -72,7 +72,7 @@ For help with a parameter, select the **?** option, or hover the parameter and p
 #### Edit Value
 
 Select **Edit Value** then enter a value. There is no need to enter the unit of the entered value.
-Press Enter to commit the change. To exit without committing the change, press Escape or focus elsewhere.
+Press Enter to commit the change. To exit without committing the change, press Esc or focus elsewhere.
 
 ![Illustration 4: Type-in window](/images/manual-xt/Pictures/typein_window.png)
 

--- a/src/content/manual_xt/04-header.mdx
+++ b/src/content/manual_xt/04-header.mdx
@@ -87,13 +87,13 @@ You can also search metadata:
 - To search by author, enter `AUTHOR=` or `AUTH=`, then part of the author name.
 - To search by category, enter `CATEGORY=` or `CAT=`, then part of the category name.
 
-By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain Patch Search Results After Loading**. To close the list with this enabled, press Ctrl while selecting a patch, or press Escape.
+By default, the list closes when you select a patch. To leave the list open, select main menu > [Workflow](#workflow) > **Retain Patch Search Results After Loading**. To close the list with this enabled, press Ctrl/Command while selecting a patch, or press Esc.
 
 ### The Save Dialog
 
 A modified or unsaved patch displays with an asterisk in the patch name area.
 
-To save a patch, select **Save**, or press Ctrl + S.
+To save a patch, select **Save**, or press Ctrl/Command + S.
 
 **Hint**: To bypass the **Save** dialog when **Confirm Patch Loading** is enabled, hold Shift when confirming with **OK**.
 
@@ -149,6 +149,6 @@ To change clipping of global output, right-click **Global Volume** then select a
 
 The level meter displays the current output level. Levels above 0 dBFS display red.
 
-To open the [oscilloscope](#oscilloscope), press Alt + O, or right-click on the level meter and select **Oscilloscope**. The oscilloscope displays a waveform or a spectrum.
+To open the [oscilloscope](#oscilloscope), press Alt/Option + O, or right-click on the level meter and select **Oscilloscope**. The oscilloscope displays a waveform or a spectrum.
 
 To display CPU usage in the level meter, right-click on the level meter and select **Show CPU Usage**.

--- a/src/content/manual_xt/05-scene-controls.mdx
+++ b/src/content/manual_xt/05-scene-controls.mdx
@@ -99,11 +99,11 @@ To change gain for a channel, move its [slider](#sliders-and-controls).
 
 To mute a channel, select **M**. Select again to unmute.
 
-To mute a channel and unmute the other channels, hold Ctrl and select **M**.
+To mute a channel and unmute the other channels, hold Ctrl/Command and select **M**.
 
 To solo a channel, select **S**. Select **S** again to unsolo. If any channel has solo enabled, then the mixer ignores all mutes.
 
-To solo a channel and unsolo the other channels, hold Ctrl and select **S**.
+To solo a channel and unsolo the other channels, hold Ctrl/Command and select **S**.
 
 To select which filters a channel routes to, select from the group of three boxes:
 
@@ -184,7 +184,7 @@ To set <a name="note-priority"></a>note priority, right-click the **Play Mode** 
 
 To set <a name="envelope-retrigger-behavior"></a>envelope retrigger behavior, right-click the **Play Mode** area and select one of: 
 
-- **Reset To Zero** to reset evenelopes to the beginning of the attack stage when you start a note. This is the default option.
+- **Reset To Zero** to reset envelopes to the beginning of the attack stage when you start a note. This is the default option.
 - **Continue From Current Level** to make envelopes continue from the level of the previous note.
 
 To set <a name="sustain-pedal-mono"></a>behavior when the sustain pedal is pressed in mono mode, right-click the **Play Mode** area, select **Sustain pedal in mono mode**, then select one of: 
@@ -246,7 +246,7 @@ Finally, the **Apply SCL/KBM tuning to filter cutoff**
 option can be accessed when the **Apply tuning after modulation** option is enabled in the Tuning menu.
 See the [microtuning](#microtuning) section for more information.
 
-**Hint**: MIDI note names help when you use the filter for melodic and tuning purposes. To snap to the frequency of the nearest note, hold Ctrl while you drag the slider.
+**Hint**: MIDI note names help when you use the filter for melodic and tuning purposes. To snap to the frequency of the nearest note, hold Ctrl/Command while you drag the slider.
 
 #### Filter Resonance
 

--- a/src/content/manual_xt/06-modulation-routing.mdx
+++ b/src/content/manual_xt/06-modulation-routing.mdx
@@ -72,7 +72,7 @@ on the mini-button on another LFO (the small orange arrow):
 
 ![Illustration 28: Modulation section](/images/manual-xt/Pictures/modulationsourceselectionbar.png)
 
-Alternatively, you can also left-click on a modulation source while holding **Ctrl / Cmd** to display it
+Alternatively, you can also left-click on a modulation source while holding **Ctrl/Command** to display it
 in the LFO editor as well.
 
 This effectively lets you **modulate the parameters of one LFO with any other mod source(s)**.
@@ -343,7 +343,7 @@ sequence will repeat once it gets into the loop. The left mouse button is
 used for drawing while the right one can be used to clear the values to
 zero.
 
-To quickly reset a step to 0, either double-click on a step, or hold down Ctrl/Cmd and click or drag with the mouse over
+To quickly reset a step to 0, either double-click on a step, or hold down Ctrl/Command and click or drag with the mouse over
 the desired step(s).
 
 Right-clicking and dragging over steps allows you to draw a straight line over the desired steps,
@@ -352,7 +352,7 @@ thus creating a perfectly linear staircase pattern.
 Holding down **Shift** while drawing will quantize the values to
 the scale degrees (1/12<sup>th</sup> in case of standard tuning, or possibly other
 for custom tuning) spanning the range of **one octave**.
-Furthermore, holding down **Shift + Alt** makes two times more values available, hence
+Furthermore, holding down **Shift + Alt/Option** makes two times more values available, hence
 useful when modulating pitch by **two octaves** instead.
 
 For more information on microtonal pitch modulation using the step sequencer, visit our
@@ -423,7 +423,7 @@ then dragging your mouse up or down. Alternatively, you can again middle-click a
 **Moving nodes**
 
 To move a node, simply left-click and drag it. To do the same with multiple nodes at the same time, you can
-Shift+left-click and drag, which makes a selection.
+Shift + left-click and drag, which makes a selection.
 
 **Adding and removing nodes**
 
@@ -464,10 +464,10 @@ At the bottom of the editor are a couple of options to configure editing modes a
 
 -   **Snap To Grid**
     -   **Horizontal** - Enables horizontal snapping to the grid. The number field to the right corresponds to the
-        horizontal grid resolution. You can also temporarily enable horizontal snapping by holding down the Ctrl/Cmd key
+        horizontal grid resolution. You can also temporarily enable horizontal snapping by holding down the Ctrl/Command key
         while dragging.
     -   **Vertical** - Enables vertical snapping to the grid. The number field to the right corresponds to the
-        vertical grid resolution. You can also temporarily enable vertical snapping by holding down the Alt key
+        vertical grid resolution. You can also temporarily enable vertical snapping by holding down the Alt/Option key
         while dragging.
 
 **Segment options**

--- a/src/content/manual_xt/07-effects.mdx
+++ b/src/content/manual_xt/07-effects.mdx
@@ -25,9 +25,9 @@ A **double-click** on a unit disables/enables it. This state is stored within pa
 unlike the global FX bypass setting.
 A **right-click** on a unit displays the effect and preset picker specifically for that unit, allowing you to directly
 add or swap an effect on that unit.
-An **Alt+Click** clears the desired FX unit.
+An **Alt/Option + Click** clears the desired FX unit.
 
-Moreover, you can drag-and-drop units over other units to make them switch places. Holding down **Ctrl/Cmd** and
+Moreover, you can drag-and-drop units over other units to make them switch places. Holding down **Ctrl/Command** and
 dragging allows you to duplicate (copy) units on other units instead, and holding **Shift** allows to simply replace
 (overwrite) the target unit with the source one.
 

--- a/src/content/manual_xt/11-accessibility.mdx
+++ b/src/content/manual_xt/11-accessibility.mdx
@@ -7,10 +7,10 @@ order: 11
 # Accessibility
 
 The Surge XT user interface can be completely navigated from the keyboard. Pressing Tab will allow you to move through all controls
-in the user interface, while pressing the up and down arrow keys will let you adjust them. Just like holding Shift or Control/Command
+in the user interface, while pressing the up and down arrow keys will let you adjust them. Just like holding Shift or Ctrl/Command
 while moving a slider with the mouse lets you make more precise adjustments, holding these modifiers while pressing the
 arrow keys will have a similar effect. Pressing Home, End or Delete will let you set a control to its maximum, minimum and default
-value respectively. Finally, pressing Shift+F10 or the Applications key on any control will open its right-click menu.
+value respectively. Finally, pressing Shift + F10 or the Applications key on any control will open its right-click menu.
 
 With the exception of Tab, the other keys mentioned here need to be turned on before they can be used. If you press one of these keys
 with the shortcuts turned off, you will be asked whether you want to turn them on. Alternatively, they can be turned on by checking the

--- a/src/content/manual_xt/12-technical-reference.mdx
+++ b/src/content/manual_xt/12-technical-reference.mdx
@@ -155,7 +155,7 @@ Once a wavetable is loaded, you can also export it using the wavetable selection
 
 Then, by modulating the **Morph** parameter, it is possible to create motion,
 dynamic response to playing and sonic variation. If you want to select an exact frame, drag the slider while holding
-down Ctrl/Cmd, which allows you to snap to exact values in the table, useful for switching between distinct
+down Ctrl/Command, which allows you to snap to exact values in the table, useful for switching between distinct
 shapes, for example.
 
 What real-life property, if any, the **Morph** parameter is supposed to mirror depend on


### PR DESCRIPTION
* Replace all instances of Cmd with Command, which is the correct name for this Mac modifier key.
* Replace all instances of Escape with Esc, which is the correct name for this key.
* Replace all instances of Ctrl with Ctrl/Command, to include both PC/Mac modifier key names.
* Replace all instances of Alt with Alt/Option, to include both PC/Mac modifier key names.
* Getting Started: Explain use of PC/Mac modifier key names.
* Locations > Windows: Missing backslash. Also, modern Windows uses "Documents" instead of "My Documents".
* Mono Play Modes: Fix "envelope" spelling error.