### PR TITLE
docs(ai tools): add surge docs mcp reference

### DIFF
--- a/src/components/home/developers.astro
+++ b/src/components/home/developers.astro
@@ -37,6 +37,14 @@ import Button from "../blue_button.astro";
             </p>
 
             <Button text="Join Surge Synth Team Discord Server" url="https://discord.gg/spGANHw" />
+
+            <p class="mt-4">
+                The community also builds integrations and tools around Surge XT. SurgeXT MCP is a
+                Model Context Protocol server that lets AI assistants like Claude and Cursor work
+                with Surge XT's documentation to help design and recreate sounds.
+            </p>
+
+            <Button text="SurgeXT MCP on GitHub" url="https://github.com/rithulkamesh/surgext-mcp" />
         </PanelText>
     </PanelItem>
 </Panel>

--- a/src/components/home/developers.astro
+++ b/src/components/home/developers.astro
@@ -39,12 +39,12 @@ import Button from "../blue_button.astro";
             <Button text="Join Surge Synth Team Discord Server" url="https://discord.gg/spGANHw" />
 
             <p class="mt-4">
-                The community also builds integrations and tools around Surge XT. SurgeXT MCP is a
+                The community also builds integrations and tools around Surge XT. Surge XT MCP is a
                 Model Context Protocol server that lets AI assistants like Claude and Cursor work
                 with Surge XT's documentation to help design and recreate sounds.
             </p>
 
-            <Button text="SurgeXT MCP on GitHub" url="https://github.com/rithulkamesh/surgext-mcp" />
+            <Button text="Surge XT MCP on GitHub" url="https://github.com/rithulkamesh/surgext-mcp" />
         </PanelText>
     </PanelItem>
 </Panel>

--- a/src/content/manual_xt/12-technical-reference.mdx
+++ b/src/content/manual_xt/12-technical-reference.mdx
@@ -1195,3 +1195,17 @@ As for the eight macros atop the routing bar, they have MIDI CCs assigned to the
 **Macro 7** = CC 47
 
 **Macro 8** = CC 48
+
+## Community Tools & Integrations
+
+### SurgeXT MCP
+
+[SurgeXT MCP](https://github.com/rithulkamesh/surgext-mcp) is a community-built [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes Surge XT's documentation to AI assistants. It enables tools like Claude, Cursor, and other MCP-compatible clients to understand Surge XT's parameter space and help users recreate or design sounds directly from natural language descriptions.
+
+Install via npm:
+
+```
+npm install -g surgext-mcp
+```
+
+Source and documentation are available at [github.com/rithulkamesh/surgext-mcp](https://github.com/rithulkamesh/surgext-mcp).

--- a/src/content/pages/faq.mdx
+++ b/src/content/pages/faq.mdx
@@ -113,3 +113,9 @@ A: Feature requests are the source of some of the best ideas in Surge XT and we 
 **Q: I have a question and need help. What should I do?**
 
 A: Join our [Discord server](https://discord.gg/spGANHw) and hop into the `#❓help` channel and ask. To make things quicker: please share your OS and DAW (if you are using a DAW) and be as specific as possible. Also, let us know if you are using a screenreader or not. Copying the info from Surge XT's About screen will often help too! Finally: just ask! No need to ask if you can ask.
+
+<hr/><br/>
+
+**Q: Can I use AI tools to help design or recreate sounds in Surge XT?**
+
+A: Yes! The community has built tools to bridge Surge XT with AI assistants. [SurgeXT MCP](https://github.com/rithulkamesh/surgext-mcp) is a Model Context Protocol server that gives AI tools (like Claude, Cursor, and others that support MCP) access to Surge XT's documentation, letting them help you recreate and design patches by referencing the synthesizer's parameters and architecture directly. You can install it from [npm](https://www.npmjs.com/package/surgext-mcp) and connect it to your AI assistant of choice.


### PR DESCRIPTION
Wrote a SurgeXT docs MCP so that I can recreate sounds with the help of AI tools like Claude/ChatGPT, added a reference to the website for others to use the same :)